### PR TITLE
PoC: returning Jelly streams from ListPage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.nanopub</groupId>
       <artifactId>nanopub</artifactId>
-      <version>1.65</version>
+      <version>1.66</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>
@@ -75,6 +75,11 @@
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
       <version>1.82</version>
+    </dependency>
+    <dependency>
+      <groupId>eu.ostrzyciel.jelly</groupId>
+      <artifactId>jelly-rdf4j_3</artifactId>
+      <version>2.3.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/knowledgepixels/registry/jelly/NanopubStream.java
+++ b/src/main/java/com/knowledgepixels/registry/jelly/NanopubStream.java
@@ -1,0 +1,96 @@
+package com.knowledgepixels.registry.jelly;
+
+import com.mongodb.client.MongoCursor;
+import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory$;
+import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jProtoEncoder;
+import eu.ostrzyciel.jelly.core.JellyOptions$;
+import eu.ostrzyciel.jelly.core.proto.v1.*;
+import org.bson.Document;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
+import scala.jdk.CollectionConverters;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.Vector;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class NanopubStream {
+    /**
+     * Create a NanopubStream from a MongoDB cursor in the "nanopubs" collection.
+     * @param cursor MongoDB cursor
+     * @return NanopubStream
+     */
+    public static NanopubStream fromMongoCursor(MongoCursor<Document> cursor) {
+        Stream<String> trigStream = StreamSupport
+                .stream(Spliterators.spliteratorUnknownSize(cursor, Spliterator.ORDERED), false)
+                .map(doc -> doc.getString("content"));
+        return new NanopubStream(trigStream);
+    }
+
+    /**
+     * Direct handler for RDF parser outputs that immediately sends the statements to the Jelly stream.
+     */
+    private static class JellyStatementHandler extends AbstractRDFHandler {
+        private final Rdf4jProtoEncoder encoder;
+        private final Vector<RdfStreamRow> rowBuffer = new Vector<>();
+
+        JellyStatementHandler(Rdf4jProtoEncoder encoder) {
+            this.encoder = encoder;
+        }
+
+        @Override
+        public void handleStatement(Statement st) {
+            encoder.addQuadStatement(st).foreach(rowBuffer::add);
+        }
+
+        /**
+         * Call this at the end of a nanopub.
+         * This flushes the buffer and returns the RdfStreamFrame corresponding to one nanopub.
+         * @return RdfStreamFrame
+         */
+        public RdfStreamFrame getFrame() {
+            var rows = CollectionConverters.CollectionHasAsScala(rowBuffer).asScala().toSeq();
+            rowBuffer.clear();
+            return RdfStreamFrame$.MODULE$.apply(rows);
+        }
+    }
+
+    private final Stream<RdfStreamFrame> frameStream;
+
+    private NanopubStream(Stream<String> trigStream) {
+        // Using the low-level Jelly API here
+        Rdf4jConverterFactory$ jellyConverter = Rdf4jConverterFactory$.MODULE$;
+        // TODO: factor out the shared options somewhere
+        RdfStreamOptions options = JellyOptions$.MODULE$.bigStrict()
+            .withStreamName("nanopub")  // TODO: use a more descriptive name
+            .withPhysicalType(PhysicalStreamType.QUADS$.MODULE$)
+            .withLogicalType(LogicalStreamType.DATASETS$.MODULE$);
+
+        Rdf4jProtoEncoder encoder = jellyConverter.encoder(options);
+        JellyStatementHandler handler = new JellyStatementHandler(encoder);
+
+        this.frameStream = trigStream.map(trig -> {
+            // TODO: this is slow, we are parsing TriG files here...
+            //   Maybe instead store the files as Jelly in the DB and here just repack them?
+            RDFParser parser = Rio.createParser(RDFFormat.TRIG);
+            parser.setRDFHandler(handler);
+            try {
+                parser.parse(new java.io.StringReader(trig));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return handler.getFrame();
+        });
+    }
+
+    public void writeToByteStream(OutputStream os) {
+        frameStream.forEach(frame -> frame.writeDelimitedTo(os));
+    }
+}


### PR DESCRIPTION
Early proof-of-concept implementation for returning lists of nanopubs as a single Jelly stream (issue #29). The data returned from the HTTP endpoint is an RDF dataset stream, so every frame in the stream corresponds to one RDF dataset (=1 nanopub).

I had to update nanopub-java to 1.66, because 1.65 has a broken dependency on the trustyuri lib.

This actually works. I can test it for example with the Jena RIOT CLI utility ([installation instructions](https://jelly-rdf.github.io/jelly-jvm/dev/getting-started-plugins/)):

```shell
curl --header "Accept: application/x-jelly-rdf" http://localhost:9292/list/1162349fdeaf431e71ab55898cb2a425b971d466150c2aa5b3c1beb498045a37/4a9a4dc2fa939033dd444d4f630fec3450eee305d98dd9945f110b2a6bb51317 | ./riot --syntax=jelly --out=trig > out.trig
```

Jena treats the whole stream as one big RDF dataset, so it will save the whole stream as a single file. But, the stream is punctuated, so a better consumer would be able to tell where one nanopub ends and another begins.

Currently, the main bottleneck is that the nanopubs are stored in TriG in the DB, so we need to parse them before encoding them in Jelly. This will be rather slow, because parsing TriG is slow in general. This works, but I have an idea how to get this to be way faster (future work):

- Add a new field to the `nanopubs` collection – `jelly` – where we would store the nanopub serialized in the Jelly format.
  - Note that this field could also be used by default for parsing instead of `content`, because it should be faster to parse than TriG.
- When returning the stream, we *could* simply concatenate these serialized byte representations and call it a day. But, in this setup we would not be exploiting the repeating patterns between nanopubs (so, recurring prefixes, same datatypes, etc.). This will result in poor ser/des performance and larger stream size in bytes. To exploit these regularities, we would need to parse each Jelly file and re-encode them as a single stream.
  - Parsing and re-encoding would be way faster than the current setup, but still not ideal, because it would necessitate converting to/from RDF4J `Statement` classes. This usually takes about 50% of CPU time in the Jelly parser and writer.
- We can get around this, if we implemented a **Jelly stream re-encoder**. This re-encoder would work on the intermediate Protobuf classes (not using RDF4J at all) and simply eliminate repeating elements in the stream. This should be 1.5–2x faster than using RDF4J Statements as the intermediate representation.

I think this re-encoder could also be useful for other projects, so I will look into implementing it in the `jelly-core` library.