### PR TITLE
Store nanopubs also in Jelly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>eu.ostrzyciel.jelly</groupId>
       <artifactId>jelly-rdf4j_3</artifactId>
-      <version>2.3.0</version>
+      <version>2.4.1</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/knowledgepixels/registry/ListPage.java
+++ b/src/main/java/com/knowledgepixels/registry/ListPage.java
@@ -56,10 +56,11 @@ public class ListPage extends Page {
 				// TODO
 				//println(ServerConf.getInfo().asJson());
 			} else if ("application/x-jelly-rdf".equals(format)) {
+				// Return all nanopubs in the list as a single Jelly stream
 				List<Bson> pipeline = List.of(
 						lookup("nanopubs", "np", "_id", "nanopub"),
-						project(new Document("content", "$nanopub.content")),
-						unwind("$content")
+						project(new Document("jelly", "$nanopub.jelly")),
+						unwind("$jelly")
 				);
 				var result = collection("list-entries").aggregate(pipeline);
 				NanopubStream npStream = NanopubStream.fromMongoCursor(result.cursor());

--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -6,12 +6,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import com.knowledgepixels.registry.jelly.JellyUtils;
 import org.bson.Document;
+import org.bson.types.Binary;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
-import org.eclipse.rdf4j.rio.RDFFormat;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
 import org.nanopub.extra.server.GetNanopub;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
@@ -71,7 +71,8 @@ public class NanopubLoader {
 		MongoCursor<Document> cursor = RegistryDB.get("nanopubs", new Document("_id", ac));
 		if (!cursor.hasNext()) return null;
 		try {
-			return new NanopubImpl(cursor.next().getString("content"), RDFFormat.TRIG);
+			// Parse from Jelly, not TriG (it's faster)
+			return JellyUtils.readFromDB(((Binary) cursor.next().get("jelly")).getData());
 		} catch (RDF4JException | MalformedNanopubException ex) {
 			ex.printStackTrace();
 			return null;

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 
+import com.knowledgepixels.registry.jelly.JellyUtils;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.bson.types.Binary;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.nanopub.Nanopub;
@@ -288,8 +290,11 @@ public class RegistryDB {
 			Long counter = (Long) getMaxValue("nanopubs", "counter");
 			if (counter == null) counter = 0l;
 			String nanopubString;
+			byte[] jellyContent;
 			try {
 				nanopubString = NanopubUtils.writeToString(nanopub, RDFFormat.TRIG);
+				// Save the same thing in the Jelly format for faster loading
+				jellyContent = JellyUtils.writeNanopubForDB(nanopub);
 			} catch (IOException ex) {
 				throw new RuntimeException(ex);
 			}
@@ -299,6 +304,7 @@ public class RegistryDB {
 						.append("counter", counter + 1)
 						.append("pubkey", ph)
 						.append("content", nanopubString)
+						.append("jelly", new Binary(jellyContent))
 				);
 
 			for (IRI invalidatedId : Utils.getInvalidatedNanopubIds(nanopub)) {

--- a/src/main/java/com/knowledgepixels/registry/jelly/JellyNanopubRDFHandler.java
+++ b/src/main/java/com/knowledgepixels/registry/jelly/JellyNanopubRDFHandler.java
@@ -1,0 +1,47 @@
+package com.knowledgepixels.registry.jelly;
+
+import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory$;
+import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jProtoEncoder;
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame;
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame$;
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions;
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
+import scala.jdk.CollectionConverters;
+
+import java.util.Vector;
+
+/**
+ * RDF4J Rio RDFHandler that converts nanopubs into Jelly RdfStreamFrames.
+ */
+public class JellyNanopubRDFHandler extends AbstractRDFHandler {
+    private final Rdf4jProtoEncoder encoder;
+    private final Vector<RdfStreamRow> rowBuffer = new Vector<>();
+
+    JellyNanopubRDFHandler(RdfStreamOptions options) {
+        // Enabling namespace declarations -- so we are using Jelly 1.1.0 here.
+        this.encoder = Rdf4jConverterFactory$.MODULE$.encoder(options, true);
+    }
+
+    @Override
+    public void handleStatement(Statement st) {
+        encoder.addQuadStatement(st).foreach(rowBuffer::add);;
+    }
+
+    @Override
+    public void handleNamespace(String prefix, String uri) {
+        encoder.declareNamespace(prefix, uri).foreach(rowBuffer::add);;
+    }
+
+    /**
+     * Call this at the end of a nanopub.
+     * This flushes the buffer and returns the RdfStreamFrame corresponding to one nanopub.
+     * @return RdfStreamFrame
+     */
+    public RdfStreamFrame getFrame() {
+        var rows = CollectionConverters.CollectionHasAsScala(rowBuffer).asScala().toSeq();
+        rowBuffer.clear();
+        return RdfStreamFrame$.MODULE$.apply(rows);
+    }
+}

--- a/src/main/java/com/knowledgepixels/registry/jelly/JellyUtils.java
+++ b/src/main/java/com/knowledgepixels/registry/jelly/JellyUtils.java
@@ -1,0 +1,38 @@
+package com.knowledgepixels.registry.jelly;
+
+import eu.ostrzyciel.jelly.core.JellyOptions$;
+import eu.ostrzyciel.jelly.core.proto.v1.*;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubUtils;
+
+/**
+ * Utility functions for working with Jelly RDF data.
+ * TODO: consider putting this in the org.nanopub.nanopub library?
+ */
+public class JellyUtils {
+    /**
+     * Options for Jelly RDF streams that are written to the database.
+     */
+    public static RdfStreamOptions jellyOptionsForDB = JellyOptions$.MODULE$.smallStrict()
+        .withPhysicalType(PhysicalStreamType.QUADS$.MODULE$)
+        .withLogicalType(LogicalStreamType.DATASETS$.MODULE$);
+
+    /**
+     * Options for Jelly RDF streams that are transmitted between services.
+     */
+    public static RdfStreamOptions jellyOptionsForTransmission = JellyOptions$.MODULE$.bigStrict()
+        .withPhysicalType(PhysicalStreamType.QUADS$.MODULE$)
+        .withLogicalType(LogicalStreamType.DATASETS$.MODULE$);
+
+    /**
+     * Write a Nanopub to bytes in the Jelly format to be stored in the database.
+     * @param np Nanopub
+     * @return Jelly RDF bytes (non-delimited)
+     */
+    public static byte[] writeNanopubForDB(Nanopub np) {
+        JellyNanopubRDFHandler handler = new JellyNanopubRDFHandler(jellyOptionsForDB);
+        NanopubUtils.propagateToHandler(np, handler);
+        RdfStreamFrame frame = handler.getFrame();
+        return frame.toByteArray();
+    }
+}

--- a/src/main/java/com/knowledgepixels/registry/jelly/JellyUtils.java
+++ b/src/main/java/com/knowledgepixels/registry/jelly/JellyUtils.java
@@ -1,15 +1,38 @@
 package com.knowledgepixels.registry.jelly;
 
+import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory$;
+import eu.ostrzyciel.jelly.convert.rdf4j.rio.package$;
 import eu.ostrzyciel.jelly.core.JellyOptions$;
+import eu.ostrzyciel.jelly.core.ProtoDecoder;
 import eu.ostrzyciel.jelly.core.proto.v1.*;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
+import org.nanopub.NanopubImpl;
 import org.nanopub.NanopubUtils;
+import scala.Option;
+import scala.Some;
+import scala.jdk.CollectionConverters;
+import scala.runtime.BoxedUnit;
+
+import java.util.Vector;
 
 /**
  * Utility functions for working with Jelly RDF data.
- * TODO: consider putting this in the org.nanopub.nanopub library?
+ * TODO: consider putting this in the nanopub-java library?
  */
 public class JellyUtils {
+
+    /**
+     * Jelly RDF format for use with RDF4J Rio.
+     */
+    public final static RDFFormat JELLY_FORMAT = package$.MODULE$.JELLY();
+
+    public final static Option<RdfStreamOptions> defaultSupportedOptions =
+        Some.apply(JellyOptions$.MODULE$.defaultSupportedOptions());
+
     /**
      * Options for Jelly RDF streams that are written to the database.
      */
@@ -30,9 +53,40 @@ public class JellyUtils {
      * @return Jelly RDF bytes (non-delimited)
      */
     public static byte[] writeNanopubForDB(Nanopub np) {
-        JellyNanopubRDFHandler handler = new JellyNanopubRDFHandler(jellyOptionsForDB);
+        JellyWriterRDFHandler handler = new JellyWriterRDFHandler(jellyOptionsForDB);
         NanopubUtils.propagateToHandler(np, handler);
         RdfStreamFrame frame = handler.getFrame();
         return frame.toByteArray();
+    }
+
+    /**
+     * Read a Nanopub from bytes in the Jelly format stored in the database.
+     * <p>
+     * This is only needed because nanopub-java does not support parsing binary data as input.
+     * Nonetheless, this should be a bit faster than going through RDF4J Rio, because we are
+     * dealing with a special (simpler) case here.
+     * TODO: fix this in nanopub-java?
+     * @param jellyBytes Jelly RDF bytes (non-delimited)
+     * @return Nanopub
+     * @throws MalformedNanopubException if this is not a valid Nanopub
+     */
+    public static Nanopub readFromDB(byte[] jellyBytes) throws MalformedNanopubException {
+        Vector<Statement> statements = new Vector<>();
+        Vector<Pair<String, String>> namespaces = new Vector<>();
+        ProtoDecoder<Statement> decoder = Rdf4jConverterFactory$.MODULE$.quadsDecoder(
+            defaultSupportedOptions,
+            ((prefix, node) -> {
+                namespaces.add(Pair.of(prefix, node.stringValue()));
+                return BoxedUnit.UNIT;
+            })
+        );
+        RdfStreamFrame frame = RdfStreamFrame$.MODULE$.parseFrom(jellyBytes);
+        CollectionConverters.SeqHasAsJava(frame.rows()).asJava().forEach(row -> {
+            Option<Statement> maybeSt = decoder.ingestRow(row);
+            if (maybeSt.isDefined()) {
+                statements.add(maybeSt.get());
+            }
+        });
+        return new NanopubImpl(statements, namespaces);
     }
 }

--- a/src/main/java/com/knowledgepixels/registry/jelly/JellyWriterRDFHandler.java
+++ b/src/main/java/com/knowledgepixels/registry/jelly/JellyWriterRDFHandler.java
@@ -15,11 +15,11 @@ import java.util.Vector;
 /**
  * RDF4J Rio RDFHandler that converts nanopubs into Jelly RdfStreamFrames.
  */
-public class JellyNanopubRDFHandler extends AbstractRDFHandler {
+public class JellyWriterRDFHandler extends AbstractRDFHandler {
     private final Rdf4jProtoEncoder encoder;
     private final Vector<RdfStreamRow> rowBuffer = new Vector<>();
 
-    JellyNanopubRDFHandler(RdfStreamOptions options) {
+    JellyWriterRDFHandler(RdfStreamOptions options) {
         // Enabling namespace declarations -- so we are using Jelly 1.1.0 here.
         this.encoder = Rdf4jConverterFactory$.MODULE$.encoder(options, true);
     }

--- a/src/main/java/com/knowledgepixels/registry/jelly/NanopubStream.java
+++ b/src/main/java/com/knowledgepixels/registry/jelly/NanopubStream.java
@@ -1,95 +1,56 @@
 package com.knowledgepixels.registry.jelly;
 
 import com.mongodb.client.MongoCursor;
-import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory$;
-import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jProtoEncoder;
-import eu.ostrzyciel.jelly.core.JellyOptions$;
+import eu.ostrzyciel.jelly.core.ProtoTranscoder;
+import eu.ostrzyciel.jelly.core.ProtoTranscoder$;
 import eu.ostrzyciel.jelly.core.proto.v1.*;
 import org.bson.Document;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.Rio;
-import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
-import scala.jdk.CollectionConverters;
+import org.bson.types.Binary;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.Vector;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class NanopubStream {
     /**
      * Create a NanopubStream from a MongoDB cursor in the "nanopubs" collection.
+     * The cursor must include the "jelly" field.
      * @param cursor MongoDB cursor
      * @return NanopubStream
      */
     public static NanopubStream fromMongoCursor(MongoCursor<Document> cursor) {
-        Stream<String> trigStream = StreamSupport
+        Stream<byte[]> jellyStream = StreamSupport
                 .stream(Spliterators.spliteratorUnknownSize(cursor, Spliterator.ORDERED), false)
-                .map(doc -> doc.getString("content"));
-        return new NanopubStream(trigStream);
-    }
-
-    /**
-     * Direct handler for RDF parser outputs that immediately sends the statements to the Jelly stream.
-     */
-    private static class JellyStatementHandler extends AbstractRDFHandler {
-        private final Rdf4jProtoEncoder encoder;
-        private final Vector<RdfStreamRow> rowBuffer = new Vector<>();
-
-        JellyStatementHandler(Rdf4jProtoEncoder encoder) {
-            this.encoder = encoder;
-        }
-
-        @Override
-        public void handleStatement(Statement st) {
-            encoder.addQuadStatement(st).foreach(rowBuffer::add);
-        }
-
-        /**
-         * Call this at the end of a nanopub.
-         * This flushes the buffer and returns the RdfStreamFrame corresponding to one nanopub.
-         * @return RdfStreamFrame
-         */
-        public RdfStreamFrame getFrame() {
-            var rows = CollectionConverters.CollectionHasAsScala(rowBuffer).asScala().toSeq();
-            rowBuffer.clear();
-            return RdfStreamFrame$.MODULE$.apply(rows);
-        }
+                .map(doc -> ((Binary) doc.get("jelly")).getData());
+        return new NanopubStream(jellyStream);
     }
 
     private final Stream<RdfStreamFrame> frameStream;
 
-    private NanopubStream(Stream<String> trigStream) {
-        // Using the low-level Jelly API here
-        Rdf4jConverterFactory$ jellyConverter = Rdf4jConverterFactory$.MODULE$;
-        // TODO: factor out the shared options somewhere
-        RdfStreamOptions options = JellyOptions$.MODULE$.bigStrict()
-            .withStreamName("nanopub")  // TODO: use a more descriptive name
-            .withPhysicalType(PhysicalStreamType.QUADS$.MODULE$)
-            .withLogicalType(LogicalStreamType.DATASETS$.MODULE$);
-
-        Rdf4jProtoEncoder encoder = jellyConverter.encoder(options);
-        JellyStatementHandler handler = new JellyStatementHandler(encoder);
-
-        this.frameStream = trigStream.map(trig -> {
-            // TODO: this is slow, we are parsing TriG files here...
-            //   Maybe instead store the files as Jelly in the DB and here just repack them?
-            RDFParser parser = Rio.createParser(RDFFormat.TRIG);
-            parser.setRDFHandler(handler);
-            try {
-                parser.parse(new java.io.StringReader(trig));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+    private NanopubStream(Stream<byte[]> jellyStream) {
+        // Merge multiple input Jelly streams (one per nanopub) into a single stream of frames.
+        //
+        // "unsafe" here is 100% fine, because we are parsing trusted input. The data comes from the DB,
+        // and it was written there by the nanopub-registry itself.
+        ProtoTranscoder transcoder = ProtoTranscoder$.MODULE$.fastMergingTranscoderUnsafe(
+            JellyUtils.jellyOptionsForTransmission
+        );
+        this.frameStream = jellyStream.map(jellyContent -> {
+            if (jellyContent == null) {
+                throw new RuntimeException("Jelly content stored in DB is null. " +
+                        "Either the database query is incorrect or the DB must be reinitialized.");
             }
-            return handler.getFrame();
+            return transcoder.ingestFrame(RdfStreamFrame$.MODULE$.parseFrom(jellyContent));
         });
     }
 
+    /**
+     * Write the NanopubStream to a byte stream (delimited).
+     * This data can be returned safely as an HTTP response body.
+     * @param os OutputStream
+     */
     public void writeToByteStream(OutputStream os) {
         frameStream.forEach(frame -> frame.writeDelimitedTo(os));
     }


### PR DESCRIPTION
Next stage of implementing #29

This adds a new field to the `nanopubs` Mongo collection (`jelly`) which holds the nanopublication serialized in the Jelly format. 

- The new field is filled in at the moment when the Nanopub is first loaded. Elsewhere in the code I assume this was really done, so you will need to drop the DB and recreate it for the code to work.
- While storing the nanopub, we preserve namespace declarations (`PREFIX` directive in TriG). This is possible now in Jelly 1.1.0.
- The nanopublication list-as-Jelly-stream endpoint was updated. Instead of parsing the nanopubs from TriG and reserializing them in Jelly for transmission, the new Jelly stream transcoder is used to merge multiple Jelly streams into one. This should be pretty efficient, as we are not fully parsing the data stored in the DB.
  - This can be tested in the same manner as in #30 – see the instructions there. Note that you need to download the newest version of the Jelly Jena plugin (2.4.1) for this to work.
  - `curl --header "Accept: application/x-jelly-rdf" http://localhost:9292/list/1162349fdeaf431e71ab55898cb2a425b971d466150c2aa5b3c1beb498045a37/4a9a4dc2fa939033dd444d4f630fec3450eee305d98dd9945f110b2a6bb51317 | ./riot --syntax=jelly --out=trig > out.trig`
- I've added a new Jelly endpoint, for retrieving individual nanopubs (in `NanopubPage.java`). This directly serves the content from the DB, only prepending it with a delimiter to be consistent with the format returned from the list endpoint.
  - This can be tested with the following command: `curl http://localhost:9292/np/RAYCNJRcdMeOJYnZ3taZ8xPXvtyhFqLAYLLQ6xjyETsmI.jelly | ./riot --syntax=jelly --out=trig`
  - Example output below.
- Finally, when nanopub-registry needs to retrieve the nanopub from DB for internal purposes (`NanopubLoader.retrieveLocalNanopub`), it does so now by parsing the Jelly data, instead of TriG.
  - The code for this part is the ugliest, because nanopub-java always forces us to use the `String`-based `Reader` class to parse nanopubs. This of course won't work with a binary format, so I wrote a very simplified, special-case parser to do the parsing.

**Example output from running**  `curl http://localhost:9292/np/RAYCNJRcdMeOJYnZ3taZ8xPXvtyhFqLAYLLQ6xjyETsmI.jelly | ./riot --syntax=jelly --out=trig`

```turtle
PREFIX this: <https://w3id.org/np/RAYCNJRcdMeOJYnZ3taZ8xPXvtyhFqLAYLLQ6xjyETsmI>
PREFIX sub: <https://w3id.org/np/RAYCNJRcdMeOJYnZ3taZ8xPXvtyhFqLAYLLQ6xjyETsmI#>
PREFIX np: <http://www.nanopub.org/nschema#>
PREFIX dct: <http://purl.org/dc/terms/>
PREFIX nt: <https://w3id.org/np/o/ntemplate/>
PREFIX npx: <http://purl.org/nanopub/x/>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX orcid: <https://orcid.org/>
PREFIX ns1: <http://purl.org/np/>
PREFIX prov: <http://www.w3.org/ns/prov#>

sub:Head {
    this:   np:hasAssertion        sub:assertion;
            np:hasProvenance       sub:provenance;
            np:hasPublicationInfo  sub:pubinfo;
            a                      np:Nanopublication .
}

sub:assertion {
    orcid:0000-0002-1267-0234
            npx:approvesOf  <https://w3id.org/np/RAkdgtmh7lHYRbEwv_K7S6jG3Z-sQAtYxE9Zpg5TG9uq8> .
}

sub:provenance {
    sub:assertion  prov:wasAttributedTo  orcid:0000-0002-1267-0234 .
}

sub:pubinfo {
    sub:sig  npx:hasAlgorithm       "RSA";
            npx:hasPublicKey        "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQD4Wj537OijfOWVtsHMznuXKISqBhtGDQZfdO6pbb4hg9EHMcUFGTLbWaPrP783PHv8HMAAPjvEkHLaOHMIknqhaIa5236lfBO3r+ljVdYBElBcLvROmwG+ZGtmPNZf7lMhI15xf5TfoaSa84AFRd5J2EXekK6PhaFQhRm1IpSYtwIDAQAB";
            npx:hasSignature        "3y9TLSZt00+sX8QUegtyQ9EzkwBUQQcMpliUZCe3TQ5zjBR1QKYSCa2aWWXu8C8Y34GNoopnID/erp28y3aXmAA93BboaqPfp77KDNHHSTR0g8R8gFFN0kSr2L/b8nryqIMgEUM12gdTff+XghepQ/E5tLFg7cz4sV71jMaaXTo=";
            npx:hasSignatureTarget  this: .
    this:   dct:created                "2024-01-25T06:43:15.418Z"^^xsd:dateTime;
            dct:creator                orcid:0000-0002-1267-0234;
            dct:license                <https://creativecommons.org/licenses/by/4.0/>;
            rdfs:label                 "Approval of: RAkdgtmh7l";
            nt:wasCreatedFromProvenanceTemplate  ns1:RANwQa4ICWS5SOjw7gp99nBpXBasapwtZF1fIM3H2gYTM;
            nt:wasCreatedFromPubinfoTemplate  ns1:RAA2MfqdBCzmz9yVWjKLXNbyfBNcwsMmOqcNUxkk1maIM;
            nt:wasCreatedFromPubinfoTemplate  ns1:RAh1gm83JiG5M6kDxXhaYT1l49nCzyrckMvTzcPn-iv90;
            nt:wasCreatedFromTemplate  ns1:RAOmr2G967CF1gAfHH49W1VJdAdjE967OxWm7G_-Vq6yc .
}
```

Namespaces are correctly preserved :) the same is true for the list endpoint.

Future work:

- Consider putting some of this code in nanopub-java to reduce ugliness.
- Requesting nanopubs from other registries in the Jelly format.