### PR TITLE
Jelly writer: speed up row buffer handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>eu.ostrzyciel.jelly</groupId>
       <artifactId>jelly-rdf4j_3</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.0</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
This PR updates Jelly-JVM to 2.5.0 (latest) and improves the handling of Jelly row buffers in `JellyWriterRDFHandler`.

2.5.0 brings a new feature where the caller of a Jelly encoder can choose to manage the row buffer by itself (see: https://github.com/Jelly-RDF/jelly-jvm/pull/251). This removes the need for double-buffering within the encoder itself, in turn reducing the amount of needed memory copies and allocations. In benchmarks I saw a ~5% performance improvement with this change.

I've updated `JellyWriterRDFHandler` to take advantage of this new feature, which should minutely speed up saving new nanopubs to the DB. I tested it on a fresh DB, it works.