### PR TITLE
Partial code for fetching nanopubs in Jelly

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/ListPage.java
+++ b/src/main/java/com/knowledgepixels/registry/ListPage.java
@@ -4,9 +4,7 @@ import static com.knowledgepixels.registry.MainPage.df1;
 import static com.knowledgepixels.registry.MainPage.df8;
 import static com.knowledgepixels.registry.RegistryDB.collection;
 import static com.knowledgepixels.registry.RegistryDB.getMaxValue;
-import static com.mongodb.client.model.Aggregates.lookup;
-import static com.mongodb.client.model.Aggregates.project;
-import static com.mongodb.client.model.Aggregates.unwind;
+import static com.mongodb.client.model.Aggregates.*;
 import static com.mongodb.client.model.Indexes.ascending;
 
 import java.io.IOException;
@@ -58,6 +56,8 @@ public class ListPage extends Page {
 			} else if ("application/x-jelly-rdf".equals(format)) {
 				// Return all nanopubs in the list as a single Jelly stream
 				List<Bson> pipeline = List.of(
+						match(new Document("pubkey", pubkey).append("type", type)),
+						sort(ascending("position")), // TODO: is this needed?
 						lookup("nanopubs", "np", "_id", "nanopub"),
 						project(new Document("jelly", "$nanopub.jelly")),
 						unwind("$jelly")

--- a/src/main/java/com/knowledgepixels/registry/jelly/MaybeNanopub.java
+++ b/src/main/java/com/knowledgepixels/registry/jelly/MaybeNanopub.java
@@ -1,0 +1,42 @@
+package com.knowledgepixels.registry.jelly;
+
+import org.nanopub.Nanopub;
+
+/**
+ * Simple wrapper around the Nanopub class that can also hold an exception.
+ * <p>
+ * This is basically the same as Try<Nanopub> in Scala.
+ */
+public class MaybeNanopub {
+    private final boolean success;
+    private final Nanopub nanopub;
+    private final Exception exception;
+
+    public MaybeNanopub(Exception ex) {
+        success = false;
+        nanopub = null;
+        exception = ex;
+    }
+
+    public MaybeNanopub(Nanopub np) {
+        success = true;
+        nanopub = np;
+        exception = null;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public boolean isFailure() {
+        return !success;
+    }
+
+    public Nanopub getNanopub() {
+        return nanopub;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+}


### PR DESCRIPTION
@tkuhn I will send you an email explaining this in a moment.

This is partial code needed to support fetching nanopubs as Jelly streams. This is not yet hooked up to the DB loader.

I've also found out that I forgot to add filters to the list endpoint previously... so instead of returning nanopubs for a given list, the app was returning ALL nanopubs in the DB. Oops. This is fixed in the PR.