### PR TITLE
Use "try-with-resource" for long DB reads

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/ListPage.java
+++ b/src/main/java/com/knowledgepixels/registry/ListPage.java
@@ -73,9 +73,11 @@ public class ListPage extends Page {
 						project(new Document("jelly", "$nanopub.jelly")),
 						unwind("$jelly")
 				);
-				var result = collection("listEntries").aggregate(mongoSession, pipeline);
-				NanopubStream npStream = NanopubStream.fromMongoCursor(result.cursor());
-				npStream.writeToByteStream(getResp().getOutputStream());
+				// TODO: try with resource should be used for all DB access, really, like here
+				try (var result = collection("listEntries").aggregate(mongoSession, pipeline).cursor()) {
+					NanopubStream npStream = NanopubStream.fromMongoCursor(result);
+					npStream.writeToByteStream(getResp().getOutputStream());
+				}
 			} else {
 				MongoCursor<Document> c = collection("listEntries")
 						.find(mongoSession, new Document("pubkey", pubkey).append("type", type))


### PR DESCRIPTION
This should prevent the stream from being auto-closed. This matters for long responses, where the consumer may be shifted to a different thread, while the cursor gets GC-ed in another thread.