### PR TITLE
Return Jelly in Text Format for .jelly.txt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>eu.ostrzyciel.jelly</groupId>
       <artifactId>jelly-rdf4j_3</artifactId>
-      <version>2.6.1</version>
+      <version>2.6.3</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/knowledgepixels/registry/NanopubPage.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubPage.java
@@ -3,7 +3,6 @@ package com.knowledgepixels.registry;
 import static com.knowledgepixels.registry.RegistryDB.collection;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import eu.ostrzyciel.jelly.core.IoUtils$;
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame$;


### PR DESCRIPTION
Jelly is a binary format, so when we send it back as text to the browser, all kinds of weird and possibly very broken characters appear. You can't really do anything meaningful in that representation (it's not meant to be viewed in this manner).

So, instead of that, I changed it to return the textual representation in the Protobuf Text Format Language (https://protobuf.dev/reference/protobuf/textformat-spec/). This representation is mostly used only for debugging, but you can also technically parse it and get valid Jelly data. It just wouldn't be very efficient.

Also updated Jelly-JVM to 2.6.3, which fixes a bug in text serialization...