### PR TITLE
Add support for remote debug in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ The current incomplete implementation is running at this public instance:
 
 ## Development
 
-You can use the attached `docker-compose.yml` to start a development environment. To build the image and start the environment, simply run:
+The recommended development environment is Docker Compose. The `docker-compose.yml` file contains a production configuration with minimal exposed ports. To add features like remote JVM debugging and Mongo Express, copy the `docker-compose.override.yml.template` file to `docker-compose.override.yml` and adjust the configuration. Then, simply run:
 
 ```bash
 ./run.sh
 ```
 
-The registry will be available at http://localhost:9292/
+**Development ports:**
 
-Additionally, you can attach a remote debugger to the running nanopub-registry container on `localhost:5005`.
+- `localhost:9292` - Nanopub Registry
+- `localhost:5005` - Remote JVM debugging of the Nanopub Registry
+- `localhost:8081` - Mongo Express

--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ The current incomplete implementation is running at this public instance:
 
 - https://registry.np.kpxl.org/
 
+
+## Development
+
+You can use the attached `docker-compose.yml` to start a development environment. To build the image and start the environment, simply run:
+
+```bash
+./run.sh
+```
+
+The registry will be available at http://localhost:9292/
+
+Additionally, you can attach a remote debugger to the running nanopub-registry container on `localhost:5005`.

--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -3,13 +3,20 @@ services:
     volumes:
       - ./target/nanopub-registry/:/usr/local/tomcat/webapps/ROOT
     environment:
+      # Enable debugging at port 5005
+      - JPDA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
       - REGISTRY_COVERAGE_TYPES=all
       - REGISTRY_COVERAGE_AGENTS=viaSetting
       - REGISTRY_SERVICE_URL=https://your.public.registry.url.com/
       - NANOPUB_REGISTRY_DB_HOST=172.17.0.1  # use shared MongoDB
+    ports:
+      - 5005:5005
+    entrypoint: 'catalina.sh jpda run'
+
   mongodb:  # disable when shared MongoDB is used
     deploy:
       replicas: 0
+
   mongo-express:
     image: mongo-express
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,19 @@ services:
     build: .
     image: nanopub/registry
     restart: unless-stopped
+    environment:
+      JPDA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
     ports:
       - 9292:8080
+      - 5005:5005
     volumes:
       - ./setting.trig:/data/setting.trig
+    entrypoint: 'catalina.sh jpda run'
     logging:
       options:
         max-size: "10m"
         max-file: "3"
+
   mongodb:
     image: mongo:7
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,10 @@ services:
     build: .
     image: nanopub/registry
     restart: unless-stopped
-    environment:
-      JPDA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
     ports:
       - 9292:8080
-      - 5005:5005
     volumes:
       - ./setting.trig:/data/setting.trig
-    entrypoint: 'catalina.sh jpda run'
     logging:
       options:
         max-size: "10m"


### PR DESCRIPTION
I've found this super-incredibly helpful... just configure a remote debug session in your IDE on port 5005 and you can set breakpoints etc. in the running registry instance.