### PR TITLE
Enum for status 2

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/DbEntryWrapper.java
+++ b/src/main/java/com/knowledgepixels/registry/DbEntryWrapper.java
@@ -2,19 +2,27 @@ package com.knowledgepixels.registry;
 
 import org.bson.Document;
 
-public class DocumentWithStatusWrapper {
+/**
+ * Wrapper for a MongoDB Entry
+ *
+ * This allows us to have more control over some fields, which are just strings on the database.
+ *
+ * Currently used for:
+ * - status: can only take values of the @EntryStatus Enum.
+ */
+public class DbEntryWrapper {
 
     public static final String statusField = "status";
 
     private final Document document;
 
-    public DocumentWithStatusWrapper(EntryStatus status) {
+    public DbEntryWrapper(EntryStatus status) {
         this.document = new Document(statusField, status.getValue());
     }
-    public DocumentWithStatusWrapper(Document document) {
+    public DbEntryWrapper(Document document) {
         this.document = document;
     }
-    public DocumentWithStatusWrapper(Document document, EntryStatus status) {
+    public DbEntryWrapper(Document document, EntryStatus status) {
         this.document = document.append(statusField, status.getValue());
     }
     public Document getDocument() {

--- a/src/main/java/com/knowledgepixels/registry/DocumentWithStatusWrapper.java
+++ b/src/main/java/com/knowledgepixels/registry/DocumentWithStatusWrapper.java
@@ -1,0 +1,23 @@
+package com.knowledgepixels.registry;
+
+import org.bson.Document;
+
+public class MongoDbDocumentWrapper {
+
+    // Inspired by https://www.mongodb.com/community/forums/t/cannot-store-java-enum-values-in-mongodb/99719/3
+    // TODO discuss: Do we want Document<T> extends Document and have a specific Config with Writer and readers,
+    // which gave us more Type Savety  @see: @RegistryDB :112
+
+    private final Document document;
+
+    public MongoDbDocumentWrapper(Document document) {
+        this.document = document;
+    }
+    public Document getDocument() {
+        return document;
+    }
+    public Document setStatus(EntryStatus status) {
+        document.append("status", status.getValue());
+        return document;
+    }
+}

--- a/src/main/java/com/knowledgepixels/registry/DocumentWithStatusWrapper.java
+++ b/src/main/java/com/knowledgepixels/registry/DocumentWithStatusWrapper.java
@@ -2,22 +2,26 @@ package com.knowledgepixels.registry;
 
 import org.bson.Document;
 
-public class MongoDbDocumentWrapper {
+public class DocumentWithStatusWrapper {
 
-    // Inspired by https://www.mongodb.com/community/forums/t/cannot-store-java-enum-values-in-mongodb/99719/3
-    // TODO discuss: Do we want Document<T> extends Document and have a specific Config with Writer and readers,
-    // which gave us more Type Savety  @see: @RegistryDB :112
+    public static final String statusField = "status";
 
     private final Document document;
 
-    public MongoDbDocumentWrapper(Document document) {
+    public DocumentWithStatusWrapper(EntryStatus status) {
+        this.document = new Document(statusField, status.getValue());
+    }
+    public DocumentWithStatusWrapper(Document document) {
         this.document = document;
+    }
+    public DocumentWithStatusWrapper(Document document, EntryStatus status) {
+        this.document = document.append(statusField, status.getValue());
     }
     public Document getDocument() {
         return document;
     }
     public Document setStatus(EntryStatus status) {
-        document.append("status", status.getValue());
+        document.append(statusField, status.getValue());
         return document;
     }
 }

--- a/src/main/java/com/knowledgepixels/registry/EntryStatus.java
+++ b/src/main/java/com/knowledgepixels/registry/EntryStatus.java
@@ -1,20 +1,24 @@
 package com.knowledgepixels.registry;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
 /**
  * The status field of several Documents, especially:
  * endorsements-loading, intro-lists, and accounts-loading.
  *
  * The states of the different Document Types are not dependant of each other.
+ *
+ * We decided to break with Java Conventions and have lowercase Enum Values,
+ * which directly represent the string in the MongoDB for aesthetic reasons.
  */
 public enum EntryStatus {
-    /** endorsements_loading, */
-    to_retrieve {
 
-    @Override
-    public String toString () {
-    return "to-retrieve"; // cannot name the enum with a dash
-    }
-    },
+    /** endorsements_loading, */
+    to_retrieve, // WARNING: Breaking Change! it was "to-retrieve" before
+    // We may avoid the change by adding an annotation
+    // @BsonProperty(value = "to-retrieve") or having a custom toString()
     /** accounts-loading */
     seen,
     /** endorsements_loading, */
@@ -42,5 +46,28 @@ public enum EntryStatus {
     /** accounts-loading */
     approved,
     /** accounts-loading */
-    contested
+    contested;
+
+    // The code is inspired by: https://www.mongodb.com/community/forums/t/cannot-store-java-enum-values-in-mongodb/99719/3
+    // It's not really necessary right now, since we call getValue by hand,
+    // we may also just call toString()...
+    @BsonProperty(value="status")
+    String status;
+
+    EntryStatus() {
+        this.status = this.toString();
+    }
+
+    public static EntryStatus fromValue(String value) {
+        for (EntryStatus e : EntryStatus.values()) {
+            if (e.toString().equals(value)) {
+                return e;
+            }
+        }
+        throw new RuntimeException("Unsupported EntryStatus Value" + value);
+    }
+
+    public String getValue() {
+        return this.status;
+    }
 }

--- a/src/main/java/com/knowledgepixels/registry/EntryStatus.java
+++ b/src/main/java/com/knowledgepixels/registry/EntryStatus.java
@@ -1,7 +1,5 @@
 package com.knowledgepixels.registry;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
 /**
@@ -16,7 +14,7 @@ import org.bson.codecs.pojo.annotations.BsonProperty;
 public enum EntryStatus {
 
     /** endorsements_loading, */
-    to_retrieve, // WARNING: Breaking Change! it was "to-retrieve" before
+    toRetrieve, // WARNING: Breaking Change! it was "to-retrieve" before
     // We may avoid the change by adding an annotation
     // @BsonProperty(value = "to-retrieve") or having a custom toString()
     /** accounts-loading */

--- a/src/main/java/com/knowledgepixels/registry/LegacyConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/LegacyConnector.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.registry;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,8 +57,8 @@ public class LegacyConnector {
 					NanopubLoader.simpleLoad(mongoSession, npUri);
 					loadedCache.put(npUri, true);
 				}
-			};
-		} catch (Exception ex) {
+			}
+		} catch (IOException ex) {
 			if (resp != null) EntityUtils.consumeQuietly(resp.getEntity());
 			ex.printStackTrace();
 			System.err.println("Request to " + url + " was not successful: " + ex.getMessage());

--- a/src/main/java/com/knowledgepixels/registry/ListPage.java
+++ b/src/main/java/com/knowledgepixels/registry/ListPage.java
@@ -203,7 +203,13 @@ public class ListPage extends Page {
 						println(" status: " + d.get("status") + ",");
 						println(" depth: " + d.get("depth") + ",");
 						println(" pathCount: " + d.get("pathCount") + ",");
-						println(" ratio: " + df8.format(d.get("ratio")) + ",");
+							// TODO is this the right fix for the problem??
+						try {
+							Object ratio = d.get("ratio");
+							println(" ratio: " + df8.format(ratio) + ",");
+						} catch (IllegalArgumentException e) {
+							println(" ratio: NOT A NUMBER !! " + d.get("ratio"));
+						}
 						println(" quota: " + d.get("quota"));
 						println("</li>");
 					}

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -108,6 +108,9 @@ public class RegistryDB {
 		collection("endorsements_loading").createIndex(mongoSession, ascending("endorsedNanopub"));
 		collection("endorsements_loading").createIndex(mongoSession, ascending("source"));
 		collection("endorsements_loading").createIndex(mongoSession, ascending("status"));
+		// zip: Hmm, not possible to set com.mongodb.client.model.WriteModel<T> here
+		// I'd currently recommend to have a package with the DB related stuff
+		// and therein a Custom Extension T of <Document>, where we could put that WriteModel<T>.
 
 		collection("agents_loading").createIndex(mongoSession, ascending("agent"), unique);
 		collection("agents_loading").createIndex(mongoSession, descending("accountCount"));

--- a/src/main/java/com/knowledgepixels/registry/ServerStatus.java
+++ b/src/main/java/com/knowledgepixels/registry/ServerStatus.java
@@ -1,9 +1,13 @@
 package com.knowledgepixels.registry;
 
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
 /**
  * Represents the status of a Task in the DB.
  */
 public enum ServerStatus {
+    // Note: If we want to fulfill Java Naming Conventions the way to go was:
+    // @BsonProperty(value="launching")
     launching,
     coreLoading,
     updating,

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -74,7 +74,7 @@ public enum Task implements Serializable {
 	LOAD_CONFIG {
 
 		public void run(ClientSession s, Document taskDoc) {
-			if (!getServerStatus(s).equals("launching")) {
+			if (getServerStatus(s) != launching) {
 				throw new RuntimeException("Illegal status for this task: " + getServerStatus(s));
 			}
 
@@ -125,7 +125,7 @@ public enum Task implements Serializable {
 		// This state is periodically executed
 
 		public void run(ClientSession s, Document taskDoc) throws Exception {
-			if (!getServerStatus(s).equals("coreLoading") && !getServerStatus(s).equals("updating")) {
+			if (getServerStatus(s) != coreLoading && getServerStatus(s) != updating) {
 				throw new RuntimeException("Illegal status for this task: " + getServerStatus(s));
 			}
 
@@ -153,14 +153,14 @@ public enum Task implements Serializable {
 							.append("pubkey", "$")
 							.append("endorsedNanopub", declarationAc)
 							.append("source", getValue(s, "setting", "current"))
-							.append("status", to_retrieve)
+							.append("status", to_retrieve.getValue())
 					);
 
 			}
 			insert(s, "accounts_loading",
 					new Document("agent", "$")
 						.append("pubkey", "$")
-						.append("status", visited)
+						.append("status", visited.getValue())
 						.append("depth", 0)
 				);
 
@@ -206,8 +206,9 @@ public enum Task implements Serializable {
 
 			int depth = taskDoc.getInteger("depth");
 
-			if (has(s, "endorsements_loading", new Document("status", to_retrieve))) {
-				Document d = getOne(s, "endorsements_loading", new Document("status", to_retrieve));
+			if (has(s, "endorsements_loading", new Document("status", to_retrieve.getValue()))) {
+				Document d = getOne(s, "endorsements_loading",
+						new DocumentWithStatusWrapper(to_retrieve).getDocument());
 
 				IntroNanopub agentIntro = getAgentIntro(s, d.getString("endorsedNanopub"));
 				if (agentIntro != null) {
@@ -229,13 +230,13 @@ public enum Task implements Serializable {
 
 						Document agent = new Document("agent", agentId).append("pubkey", agentPubkey);
 						if (!has(s, "accounts_loading", agent)) {
-							insert(s, "accounts_loading", agent.append("status", seen).append("depth", depth));
+							insert(s, "accounts_loading", agent.append("status", seen.getValue()).append("depth", depth));
 						}
 					}
 
-					set(s, "endorsements_loading", d.append("status", retrieved));
+					set(s, "endorsements_loading", d.append("status", retrieved.getValue()));
 				} else {
-					set(s, "endorsements_loading", d.append("status", discarded));
+					set(s, "endorsements_loading", d.append("status", discarded.getValue()));
 				}
 
 				schedule(s, LOAD_DECLARATIONS.with("depth", depth));
@@ -274,7 +275,7 @@ public enum Task implements Serializable {
 			int depth = taskDoc.getInteger("depth");
 
 			Document d = getOne(s, "accounts_loading",
-					new Document("status", visited)
+					new Document("status", visited.getValue())
 						.append("depth", depth - 1)
 				);
 
@@ -326,7 +327,7 @@ public enum Task implements Serializable {
 						insert(s, "trustPaths_loading", pd.append("ratio", newRatio));
 					}
 					set(s, "trustPaths_loading", trustPath.append("type", "primary"));
-					set(s, "accounts_loading", d.append("status", expanded));
+					set(s, "accounts_loading", d.append("status", expanded.getValue()));
 				}
 				schedule(s, EXPAND_TRUST_PATHS.with("depth", depth));
 	
@@ -378,7 +379,8 @@ public enum Task implements Serializable {
 			int depth = taskDoc.getInteger("depth");
 			int loadCount = taskDoc.getInteger("load-count");
 
-			Document agentAccount = getOne(s, "accounts_loading", new Document("depth", depth).append("status", seen));
+			Document agentAccount = getOne(s, "accounts_loading",
+					new Document("depth", depth).append("status", seen.getValue()));
 			Document trustPath = null;
 			final String agentId;
 			final String pubkeyHash;
@@ -398,10 +400,10 @@ public enum Task implements Serializable {
 			if (trustPath == null) {
 				schedule(s, FINISH_ITERATION.with("depth", depth).append("load-count", loadCount));
 			} else if (trustPath.getDouble("ratio") < MIN_TRUST_PATH_RATIO) {
-				set(s, "accounts_loading", agentAccount.append("status", skipped));
+				set(s, "accounts_loading", agentAccount.append("status", skipped.getValue()));
 				Document d = new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH);
 				if (!has(s, "lists", d)) {
-					insert(s, "lists", d.append("status", encountered));
+					insert(s, "lists", d.append("status", encountered.getValue()));
 				}
 				schedule(s, LOAD_CORE.with("depth", depth).append("load-count", loadCount + 1));
 			} else {
@@ -409,7 +411,7 @@ public enum Task implements Serializable {
 				Document introList = new Document()
 						.append("pubkey", pubkeyHash)
 						.append("type", INTRO_TYPE_HASH)
-						.append("status", loading);
+						.append("status", loading.getValue());
 				if (!has(s, "lists", new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH))) {
 					insert(s, "lists", introList);
 				}
@@ -427,15 +429,13 @@ public enum Task implements Serializable {
 					});
 				}
 
-				set(s, "lists", introList.append("status", loaded));
+				set(s, "lists", introList.append("status", loaded.getValue()));
 
 				// TODO check endorsement limit
 				Document endorseList = new Document()
 						.append("pubkey", pubkeyHash)
 						.append("type", ENDORSE_TYPE_HASH)
-						.append("status", loading);
-				// TODO discuss about inheriting EndoresList from Document
-				//  for type safety and convenience
+						.append("status", loading.getValue());
 				if (!has(s, "lists", new Document("pubkey", pubkeyHash).append("type", ENDORSE_TYPE_HASH))) {
 					insert(s, "lists", endorseList);
 				}
@@ -459,7 +459,8 @@ public enum Task implements Serializable {
 										.append("endorsedNanopub", endorsedNpId)
 										.append("source", sourceNpId);
 								if (!has(s, "endorsements_loading", endorsement)) {
-									insert(s, "endorsements_loading", endorsement.append("status", to_retrieve));
+									insert(s, "endorsements_loading",
+											endorsement.append("status", to_retrieve.getValue()));
 								}
 							}
 						});
@@ -481,18 +482,20 @@ public enum Task implements Serializable {
 									.append("endorsedNanopub", endorsedNpId)
 									.append("source", sourceNpId);
 							if (!has(s, "endorsements_loading", endorsement)) {
-								insert(s, "endorsements_loading", endorsement.append("status", to_retrieve));
+								insert(s, "endorsements_loading",
+										endorsement.append("status", to_retrieve.getValue()));
 							}
 						}
 					});
 				}
 
-				set(s, "lists", endorseList.append("status", loaded));
+				set(s, "lists", endorseList.append("status", loaded.getValue()));
 
 				Document df = new Document("pubkey", pubkeyHash).append("type", "$");
-				if (!has(s, "lists", df)) insert(s, "lists", df.append("status", encountered));
+				if (!has(s, "lists", df)) insert(s, "lists",
+						df.append("status", encountered.getValue()));
 
-				set(s, "accounts_loading", agentAccount.append("status", visited));
+				set(s, "accounts_loading", agentAccount.append("status", visited.getValue()));
 
 				schedule(s, LOAD_CORE.with("depth", depth).append("load-count", loadCount + 1));
 			}
@@ -545,7 +548,7 @@ public enum Task implements Serializable {
 
 		public void run(ClientSession s, Document taskDoc) {
 
-			Document d = getOne(s, "accounts_loading", new Document("status", expanded));
+			Document d = getOne(s, "accounts_loading", new Document("status", expanded.getValue()));
 
 			if (d == null) {
 				schedule(s, AGGREGATE_AGENTS);
@@ -580,7 +583,7 @@ public enum Task implements Serializable {
 					quota = MAX_USER_QUOTA;
 				}
 				set(s, "accounts_loading",
-						d.append("status", processed)
+						d.append("status", processed.getValue())
 							.append("ratio", ratio)
 							.append("pathCount", pathCount)
 							.append("quota", quota)
@@ -599,11 +602,11 @@ public enum Task implements Serializable {
 
 		public void run(ClientSession s, Document taskDoc) {
 
-			Document a = getOne(s, "accounts_loading", new Document("status", processed));
+			Document a = getOne(s, "accounts_loading", new Document("status", processed.getValue()));
 			if (a == null) {
 				schedule(s, ASSIGN_PUBKEYS);
 			} else {
-				Document agentId = new Document("agent", a.getString("agent")).append("status", processed);
+				Document agentId = new Document("agent", a.getString("agent")).append("status", processed.getValue());
 				int count = 0;
 				int pathCountSum = 0;
 				double totalRatio = 0.0d;
@@ -614,7 +617,8 @@ public enum Task implements Serializable {
 					pathCountSum += d.getInteger("pathCount");
 					totalRatio += d.getDouble("ratio");
 				}
-				collection("accounts_loading").updateMany(s, agentId, new Document("$set", new Document("status", aggregated)));
+				collection("accounts_loading").updateMany(s, agentId, new Document("$set",
+						new DocumentWithStatusWrapper(aggregated).getDocument()));
 				insert(s, "agents_loading",
 						agentId.append("accountCount", count)
 							.append("avgPathCount", (double) pathCountSum / count)
@@ -634,22 +638,24 @@ public enum Task implements Serializable {
 
 		public void run(ClientSession s, Document taskDoc) {
 
-			Document a = getOne(s, "accounts_loading", new Document("status", aggregated));
+			Document a = getOne(s, "accounts_loading", new DocumentWithStatusWrapper(aggregated).getDocument());
 			if (a == null) {
 				schedule(s, DETERMINE_UPDATES);
 			} else {
 				Document pubkeyId = new Document("pubkey", a.getString("pubkey"));
 				if (collection("accounts_loading").countDocuments(s, pubkeyId) == 1) {
-					collection("accounts_loading").updateMany(s, pubkeyId, new Document("$set", new Document("status", approved)));
+					collection("accounts_loading").updateMany(s, pubkeyId,
+							new Document("$set", new DocumentWithStatusWrapper(approved).getDocument()));
 				} else {
 					// TODO At the moment all get marked as 'contested'; implement more nuanced algorithm
-					collection("accounts_loading").updateMany(s, pubkeyId, new Document("$set", new Document("status", contested)));
+					collection("accounts_loading").updateMany(s, pubkeyId, new Document("$set",
+							new DocumentWithStatusWrapper( contested).getDocument()));
 				}
 				schedule(s, ASSIGN_PUBKEYS);
 			}
-			
+
 		}
-		
+
 	},
 
 	DETERMINE_UPDATES {
@@ -660,13 +666,15 @@ public enum Task implements Serializable {
 		public void run(ClientSession s, Document taskDoc) {
 
 			// TODO Handle contested accounts properly:
-			for (Document d : collection("accounts_loading").find(new Document("status", approved))) {
+			for (Document d : collection("accounts_loading").find(
+					new DocumentWithStatusWrapper(approved).getDocument())) {
 				// TODO Consider quota too:
 				Document accountId = new Document("agent", d.get("agent")).append("pubkey", d.get("pubkey"));
-				if (collection("accounts") == null || !has(s, "accounts", accountId.append("status", loaded))) {
-					set(s, "accounts_loading", d.append("status", toLoad));
+				if (collection("accounts") == null || !has(s, "accounts",
+						accountId.append("status", loaded.getValue()))) {
+					set(s, "accounts_loading", d.append("status", toLoad.getValue()));
 				} else {
-					set(s, "accounts_loading", d.append("status", loaded));
+					set(s, "accounts_loading", d.append("status", loaded.getValue()));
 				}
 			}
 			schedule(s, FINALIZE_TRUST_STATE);
@@ -713,7 +721,7 @@ public enum Task implements Serializable {
 					);
 			}
 
-			if (status.equals("coreLoading")) {
+			if (status == coreLoading) {
 				setServerStatus(s, coreReady);
 			} else {
 				setServerStatus(s, ready);
@@ -730,7 +738,7 @@ public enum Task implements Serializable {
 		public void run(ClientSession s, Document taskDoc) {
 
 			ServerStatus status = getServerStatus(s);
-			if (status.equals("ready")) {
+			if (status == ready) {
 				setServerStatus(s, updating);
 				schedule(s, INIT_COLLECTIONS);
 			} else {
@@ -748,16 +756,16 @@ public enum Task implements Serializable {
 			if (!PERFORM_FULL_LOAD) return;
 
 			ServerStatus status = getServerStatus(s);
-			if (!status.equals("coreReady") && !status.equals("ready")) {
+			if (status != coreReady && status != ready) {
 				System.err.println("Server currently not ready; checking again later");
 				schedule(s, LOAD_FULL.withDelay(60 * 1000));
 				return;
 			}
 
-			Document a = getOne(s, "accounts", new Document("status", toLoad));
+			Document a = getOne(s, "accounts", new DocumentWithStatusWrapper(toLoad).getDocument());
 			if (a == null) {
 				System.err.println("Nothing to load");
-				if (status.equals("coreReady")) {
+				if (status == coreReady) {
 					System.err.println("Full load finished");
 					setServerStatus(s, ready);
 				}
@@ -782,8 +790,8 @@ public enum Task implements Serializable {
 				}
 
 				Document l = getOne(s, "lists", new Document().append("pubkey", ph).append("type", "$"));
-				if (l != null) set(s, "lists", l.append("status", loaded));
-				set(s, "accounts", a.append("status", loaded));
+				if (l != null) set(s, "lists", l.append("status", loaded.getValue()));
+				set(s, "accounts", a.append("status", loaded.getValue()));
 
 				schedule(s, LOAD_FULL.withDelay(100));
 			}
@@ -805,7 +813,7 @@ public enum Task implements Serializable {
 				String pubkeyHash = e.get("pubkeyhash");
 				Document d = new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH);
 				if (!has(s, "lists", d)) {
-					insert(s, "lists", d.append("status", encountered));
+					insert(s, "lists", d.append("status", encountered.getValue()));
 				}
 			}
 
@@ -817,7 +825,7 @@ public enum Task implements Serializable {
 	RUN_OPTIONAL_LOAD {
 
 		public void run(ClientSession s, Document taskDoc) {
-			Document di = getOne(s, "lists", new Document("type", INTRO_TYPE_HASH).append("status", encountered));
+			Document di = getOne(s, "lists", new Document("type", INTRO_TYPE_HASH).append("status", encountered.getValue()));
 			if (di != null) {
 				final String pubkeyHash = di.getString("pubkey");
 				System.err.println("Optional core loading: " + pubkeyHash);
@@ -834,7 +842,7 @@ public enum Task implements Serializable {
 						loadNanopub(s, NanopubLoader.retrieveNanopub(s, e.get("np")), pubkeyHash, INTRO_TYPE);
 					});
 				}
-				set(s, "lists", di.append("status", loaded));
+				set(s, "lists", di.append("status", loaded.getValue()));
 
 				if (PEER_LOADING_TESTING_MODE) {
 					try (var stream = NanopubLoader.retrieveNanopubsFromPeers(ENDORSE_TYPE_HASH, pubkeyHash)) {
@@ -851,19 +859,19 @@ public enum Task implements Serializable {
 
 				Document de = new Document("pubkey", pubkeyHash).append("type", ENDORSE_TYPE_HASH);
 				if (has(s, "lists", de)) {
-					set(s, "lists", de.append("status", loaded));
+					set(s, "lists", de.append("status", loaded.getValue()));
 				} else {
-					insert(s, "lists", de.append("status", loaded));
+					insert(s, "lists", de.append("status", loaded.getValue()));
 				}
 
 				Document df = new Document("pubkey", pubkeyHash).append("type", "$");
-				if (!has(s, "lists", df)) insert(s, "lists", df.append("status", encountered));
+				if (!has(s, "lists", df)) insert(s, "lists", df.append("status", encountered.getValue()));
 
 				schedule(s, CHECK_NEW.withDelay(100));
 				return;
 			}
 
-			Document df = getOne(s, "lists", new Document("type", "$").append("status", encountered));
+			Document df = getOne(s, "lists", new Document("type", "$").append("status", encountered.getValue()));
 			if (df != null) {
 				final String pubkeyHash = df.getString("pubkey");
 				System.err.println("Optional full loading: " + pubkeyHash);
@@ -882,7 +890,7 @@ public enum Task implements Serializable {
 					});
 				}
 
-				set(s, "lists", df.append("status", loaded));
+				set(s, "lists", df.append("status", loaded.getValue()));
 			}
 
 			schedule(s, CHECK_NEW.withDelay(100));
@@ -1046,7 +1054,7 @@ public enum Task implements Serializable {
 	}
 
 	private static void setServerStatus(ClientSession mongoSession, ServerStatus status) {
-		setValue(mongoSession, "serverInfo", "status", status);
+		setValue(mongoSession, "serverInfo", "status", status.toString());
 	}
 
 	private static ServerStatus getServerStatus(ClientSession mongoSession) {


### PR DESCRIPTION
### Created enum for ServerStatus and DocumentStatus

- fixed db problem from 1st commit
- for convenience added a Mongo Wrapper for DbEntries with status field

**WARNING: BREAKING Change in DB**
status: "to-retrieve" is now "toRetrieve"

ready to merge/rebase.



