### PR TITLE
Enable Remote Debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,6 @@ RUN mvn install -o && \
 WORKDIR $APP_DIR
 
 EXPOSE 9292
+EXPOSE 5005
 
-ENTRYPOINT ["java","-jar","nanopub-registry.jar"]
+ENTRYPOINT ["java","-jar","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005","nanopub-registry.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     restart: unless-stopped
     ports:
       - 9292:9292
+      - 5005:5005
     volumes:
       - ./setting.trig:/data/setting.trig
     logging:

--- a/src/main/java/com/knowledgepixels/registry/EntryStatus.java
+++ b/src/main/java/com/knowledgepixels/registry/EntryStatus.java
@@ -50,7 +50,7 @@ public enum EntryStatus {
     // It's not really necessary right now, since we call getValue by hand,
     // we may also just call toString()...
     @BsonProperty(value="status")
-    String status;
+    final String status;
 
     EntryStatus() {
         this.status = this.toString();


### PR DESCRIPTION
### Enable Remote Debugging

Start the nano pub registry with remote debugging enabled, so an IDE may connect to port 5005 of the container. This allows us easier debugging, with breakpoints, variable views, ...

IDE Connection:
`localhost:5005`
`-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005`

**WARNING: We probably don't want this behavior on PROD instances.**

by: zip