### PR TITLE
Update Jelly-JVM to 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>eu.ostrzyciel.jelly</groupId>
       <artifactId>jelly-rdf4j_3</artifactId>
-      <version>2.6.4</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/knowledgepixels/registry/jelly/JellyUtils.java
+++ b/src/main/java/com/knowledgepixels/registry/jelly/JellyUtils.java
@@ -132,9 +132,9 @@ public class JellyUtils {
             RdfStreamFrame frame, ProtoDecoder<Statement> decoder, Vector<Statement> statements
     ) {
         CollectionConverters.SeqHasAsJava(frame.rows()).asJava().forEach(row -> {
-            Option<Statement> maybeSt = decoder.ingestRow(row);
-            if (maybeSt.isDefined()) {
-                statements.add(maybeSt.get());
+            Statement maybeSt = (Statement) decoder.ingestRowFlat(row);
+            if (maybeSt != null) {
+                statements.add(maybeSt);
             }
         });
     }

--- a/src/main/java/com/knowledgepixels/registry/jelly/JellyWriterRDFHandler.java
+++ b/src/main/java/com/knowledgepixels/registry/jelly/JellyWriterRDFHandler.java
@@ -1,13 +1,13 @@
 package com.knowledgepixels.registry.jelly;
 
 import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory$;
-import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jProtoEncoder;
 import eu.ostrzyciel.jelly.core.ProtoEncoder;
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame;
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame$;
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions;
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
 import scala.Some$;
 import scala.collection.mutable.ListBuffer;
@@ -16,7 +16,7 @@ import scala.collection.mutable.ListBuffer;
  * RDF4J Rio RDFHandler that converts nanopubs into Jelly RdfStreamFrames.
  */
 public class JellyWriterRDFHandler extends AbstractRDFHandler {
-    private final Rdf4jProtoEncoder encoder;
+    private final ProtoEncoder<Value, Statement, Statement, ?> encoder;
     private final ListBuffer<RdfStreamRow> rowBuffer = new ListBuffer<>();
 
     JellyWriterRDFHandler(RdfStreamOptions options) {


### PR DESCRIPTION
This release brings a new, Option[]-less interface for parsing Jelly frames. It avoids the overhead of allocating an instance of `Some[Statement]` for each triple, and thus should be slightly faster.

See: https://github.com/Jelly-RDF/jelly-jvm/pull/282