### PR TITLE
Implement an "all Nanopubs endpoint"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,13 @@
     <launcher.class>io.vertx.core.Launcher</launcher.class>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+
   <licenses>
     <license>
       <name>MIT license</name>
@@ -86,10 +93,16 @@
       <artifactId>rdf4j-rio-jsonld</artifactId>
       <version>${rdf4j.version}</version>
     </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.nanopub</groupId>-->
+<!--      <artifactId>nanopub</artifactId>-->
+<!--      <version>1.70-snapshot</version>-->
+<!--    </dependency>-->
+    <!-- Temporary: dependency on Jitpack for snapshot builds -->
     <dependency>
-      <groupId>org.nanopub</groupId>
-      <artifactId>nanopub</artifactId>
-      <version>1.69</version>
+      <groupId>com.github.Nanopublication</groupId>
+      <artifactId>nanopub-java</artifactId>
+      <version>1b55c03442929f4195ef19b66a847308386f7261</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>
@@ -119,7 +132,7 @@
     <dependency>
       <groupId>eu.ostrzyciel.jelly</groupId>
       <artifactId>jelly-rdf4j_3</artifactId>
-      <version>2.7.0</version>
+      <version>2.8.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/knowledgepixels/registry/Page.java
+++ b/src/main/java/com/knowledgepixels/registry/Page.java
@@ -129,6 +129,18 @@ public abstract class Page {
 		return context.request().path();
 	}
 
+	/**
+	 * Get a parameter from the request.
+	 * @param name The name of the parameter.
+	 * @param defaultValue The default value of the parameter.
+	 * @return The value of the parameter.
+	 */
+	public String getParam(String name, String defaultValue) {
+		String value = context.request().getParam(name);
+		if (value == null) value = defaultValue;
+		return value;
+	}
+
 	public boolean isEmpty() {
 		return requestString.isEmpty();
 	}

--- a/src/main/java/com/knowledgepixels/registry/Utils.java
+++ b/src/main/java/com/knowledgepixels/registry/Utils.java
@@ -118,4 +118,10 @@ public class Utils {
 	public static final IRI INTRO_TYPE = vf.createIRI("http://purl.org/nanopub/x/declaredBy");
 	public static final IRI APPROVAL_TYPE = vf.createIRI("http://purl.org/nanopub/x/approvesOf");
 
+	public static final String TYPE_JSON = "application/json";
+	public static final String TYPE_JELLY = "application/x-jelly-rdf";
+	public static final String TYPE_HTML = "text/html";
+
+	// Content types supported on a ListPage
+	public static final String SUPPORTED_TYPES_LIST = TYPE_JSON + "," + TYPE_JELLY + "," + TYPE_HTML;
 }


### PR DESCRIPTION
This uses a snapshot release of nanopub-java, compiled via Jitpack.

I've extended the `/nanopubs` endpoint to return all nanopublications in a single Jelly stream, along with their counter field. You can request the stream to start at any point, using the `afterCounter` parameter. For example:

```
GET /nanopubs.jelly?afterCounter=1000
```

will get you nanopubs with ID 1001, 1002, etc.

This way you can simply pass the last seen counter value to that parameter and get the continuation.

I've also factored out the media type constants, to make the media type checks a bit less error-prone.

I have also noticed that while the response streams can get pretty long (up to 50MB in my testing on localhost), the Mongo transaction gets aborted somewhere in the middle, and not all nanopubs get returned. I'm not sure what's exactly the issue, this will require some more debugging.