### PR TITLE
Add env var to configure location of setting.trig

### DIFF
--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -7,6 +7,7 @@ services:
       - REGISTRY_COVERAGE_AGENTS=viaSetting
 #     - REGISTRY_PERFORM_FULL_LOAD=false
 #     - REGISTRY_TEST_INSTANCE=true  # Set as test instance; only has an effect on DB initialization
+#     - REGISTRY_SETTING_FILE=/data/registry.trig
 #     - REGISTRY_SERVICE_URL=https://your.public.registry.url.com/
 #     - REGISTRY_DB_HOST=172.17.0.1  # use shared MongoDB
 #   ports: !override

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -998,11 +998,13 @@ public enum Task implements Serializable {
 		}
 	}
 
+	private static final String SETTING_FILE_PATH =
+			Utils.getEnv("REGISTRY_SETTING_FILE", "/data/setting.trig");
 	private static NanopubSetting settingNp;
 
 	private static NanopubSetting getSetting() throws RDF4JException, MalformedNanopubException, IOException {
 		if (settingNp == null) {
-			settingNp = new NanopubSetting(new NanopubImpl(new File("/data/setting.trig")));
+			settingNp = new NanopubSetting(new NanopubImpl(new File(SETTING_FILE_PATH)));
 		}
 		return settingNp;
 	}


### PR DESCRIPTION
The default location would not be accessible in a local setup (not in Docker). Such a setup is required for profiling, for example, because profilers generally aren't able to instrument JVM processes running in containers.