### PR TITLE
(Nanopub|List)Page: minor cleanup of constants

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/ListPage.java
+++ b/src/main/java/com/knowledgepixels/registry/ListPage.java
@@ -2,6 +2,7 @@ package com.knowledgepixels.registry;
 
 import static com.knowledgepixels.registry.RegistryDB.collection;
 import static com.knowledgepixels.registry.RegistryDB.unhash;
+import static com.knowledgepixels.registry.Utils.*;
 import static com.mongodb.client.model.Aggregates.lookup;
 import static com.mongodb.client.model.Aggregates.match;
 import static com.mongodb.client.model.Aggregates.project;
@@ -29,7 +30,7 @@ import io.vertx.ext.web.RoutingContext;
 
 public class ListPage extends Page {
 
-	private static Gson gson = new Gson();
+	private static final Gson gson = new Gson();
 
 	public static void show(RoutingContext context) {
 		ListPage page;
@@ -55,11 +56,11 @@ public class ListPage extends Page {
 		String ext = getExtension();
 		final String req = getRequestString();
 		if ("json".equals(ext)) {
-			format = Utils.TYPE_JSON;
+			format = TYPE_JSON;
 		} else if ("jelly".equals(ext)) {
-			format = Utils.TYPE_JELLY;
+			format = TYPE_JELLY;
 		} else if (ext == null || "html".equals(ext)) {
-			format = Utils.getMimeType(context, Utils.SUPPORTED_TYPES_LIST);
+			format = Utils.getMimeType(context, SUPPORTED_TYPES_LIST);
 		} else {
 			context.response().setStatusCode(400).setStatusMessage("Invalid request: " + getFullRequest());
 			return;
@@ -75,7 +76,7 @@ public class ListPage extends Page {
 			String pubkey = req.replaceFirst("/list/([0-9a-f]{64})/([0-9a-f]{64}|\\$)", "$1");
 			String type = req.replaceFirst("/list/([0-9a-f]{64})/([0-9a-f]{64}|\\$)", "$2");
 
-			if (Utils.TYPE_JELLY.equals(format)) {
+			if (TYPE_JELLY.equals(format)) {
 				// Return all nanopubs in the list as a single Jelly stream
 				List<Bson> pipeline = List.of(
 						match(new Document("pubkey", pubkey).append("type", type)),
@@ -98,7 +99,7 @@ public class ListPage extends Page {
 						.sort(ascending("position"))
 						.cursor();
 
-				if (Utils.TYPE_JSON.equals(format)) {
+				if (TYPE_JSON.equals(format)) {
 					println("[");
 					while (c.hasNext()) {
 						Document d = c.next();
@@ -135,7 +136,7 @@ public class ListPage extends Page {
 		} else if (req.matches("/list/[0-9a-f]{64}")) {
 			String pubkey = req.replaceFirst("/list/([0-9a-f]{64})", "$1");
 			MongoCursor<Document> c = collection("lists").find(mongoSession, new Document("pubkey", pubkey)).projection(exclude("_id")).cursor();
-			if (Utils.TYPE_JSON.equals(format)) {
+			if (TYPE_JSON.equals(format)) {
 				println("[");
 				while (c.hasNext()) {
 					print(c.next().toJson());
@@ -177,7 +178,7 @@ public class ListPage extends Page {
 					.projection(exclude("_id"))
 					.cursor()
 			) {
-				if (Utils.TYPE_JSON.equals(format)) {
+				if (TYPE_JSON.equals(format)) {
 					println("[");
 					while (c.hasNext()) {
 						print(c.next().toJson());
@@ -224,7 +225,7 @@ public class ListPage extends Page {
 			}
 		} else if (req.equals("/agent") && context.request().getParam("id") != null) {
 			String agentId = context.request().getParam("id");
-			if (Utils.TYPE_JSON.equals(format)) {
+			if (TYPE_JSON.equals(format)) {
 				print(AgentInfo.get(mongoSession, agentId).asJson());
 			} else {
 				Document agentDoc = RegistryDB.getOne(mongoSession, "agents", new Document("agent", agentId));
@@ -251,7 +252,7 @@ public class ListPage extends Page {
 		} else if (req.equals("/agentAccounts") && context.request().getParam("id") != null) {
 			String agentId = context.request().getParam("id");
 			MongoCursor<Document> c = collection("accounts").find(mongoSession, new Document("agent", agentId)).projection(exclude("_id")).cursor();
-			if (Utils.TYPE_JSON.equals(format)) {
+			if (TYPE_JSON.equals(format)) {
 				println("[");
 				while (c.hasNext()) {
 					print(c.next().toJson());
@@ -286,7 +287,7 @@ public class ListPage extends Page {
 			}
 		} else if (req.equals("/agents")) {
 			MongoCursor<Document> c = collection("agents").find(mongoSession).sort(descending("totalRatio")).projection(exclude("_id")).cursor();
-			if (Utils.TYPE_JSON.equals(format)) {
+			if (TYPE_JSON.equals(format)) {
 				println("[");
 				while (c.hasNext()) {
 					print(c.next().toJson());
@@ -319,7 +320,7 @@ public class ListPage extends Page {
 				printHtmlFooter();
 			}
 		} else if (req.equals("/nanopubs")) {
-			if (Utils.TYPE_JELLY.equals(format)) {
+			if (TYPE_JELLY.equals(format)) {
 				// Return all nanopubs from after counter X (-1 by default)
 				long afterCounter;
 				try {
@@ -349,7 +350,7 @@ public class ListPage extends Page {
 				// Return latest nanopubs
 
 				MongoCursor<Document> c = collection("nanopubs").find(mongoSession).sort(descending("counter")).limit(1000).cursor();
-				if (Utils.TYPE_JSON.equals(format)) {
+				if (TYPE_JSON.equals(format)) {
 					println("[");
 					while (c.hasNext()) {
 						print(gson.toJson(c.next().getString("_id")));

--- a/src/main/java/com/knowledgepixels/registry/NanopubPage.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubPage.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.registry;
 
 import static com.knowledgepixels.registry.RegistryDB.collection;
+import static com.knowledgepixels.registry.Utils.*;
 
 import java.io.IOException;
 
@@ -40,12 +41,11 @@ public class NanopubPage extends Page {
 		String ext = getExtension();
 		final String req = getRequestString();
 		if ("trig".equals(ext)) {
-			format = "application/trig";
+			format = TYPE_TRIG;
 		} else if ("jelly".equals(ext)) {
-			format = "application/x-jelly-rdf";
+			format = TYPE_JELLY;
 		} else if (ext == null || "html".equals(ext)) {
-			String suppFormats = "application/x-jelly-rdf,application/trig,text/html";
-			format = Utils.getMimeType(c, suppFormats);
+			format = Utils.getMimeType(c, SUPPORTED_TYPES_NANOPUB);
 		} else {
 			c.response().setStatusCode(400).setStatusMessage("Invalid request: " + getFullRequest());
 			return;
@@ -68,9 +68,9 @@ public class NanopubPage extends Page {
 				return;
 			}
 	//		String url = ServerConf.getInfo().getPublicUrl();
-			if ("application/trig".equals(format)) {
+			if (TYPE_TRIG.equals(format)) {
 				println(npDoc.getString("content"));
-			} else if ("application/x-jelly-rdf".equals(format)) {
+			} else if (TYPE_JELLY.equals(format)) {
 				if (presentationFormat != null && presentationFormat.startsWith("text")) {
 					// Parse the Jelly frame and return it as Protobuf Text Format Language
 					// https://protobuf.dev/reference/protobuf/textformat-spec/
@@ -80,8 +80,6 @@ public class NanopubPage extends Page {
 				} else {
 					// To return this correctly, we would need to prepend the delimiter byte before the Jelly frame
 					// (the DB stores is non-delimited and the HTTP response must be delimited).
-
-					// Does this work???
 					BufferOutputStream outputStream = new BufferOutputStream();
 					IoUtils$.MODULE$.writeFrameAsDelimited(
 							((Binary) npDoc.get("jelly")).getData(),

--- a/src/main/java/com/knowledgepixels/registry/Utils.java
+++ b/src/main/java/com/knowledgepixels/registry/Utils.java
@@ -119,9 +119,12 @@ public class Utils {
 	public static final IRI APPROVAL_TYPE = vf.createIRI("http://purl.org/nanopub/x/approvesOf");
 
 	public static final String TYPE_JSON = "application/json";
+	public static final String TYPE_TRIG = "application/trig";
 	public static final String TYPE_JELLY = "application/x-jelly-rdf";
 	public static final String TYPE_HTML = "text/html";
 
 	// Content types supported on a ListPage
 	public static final String SUPPORTED_TYPES_LIST = TYPE_JSON + "," + TYPE_JELLY + "," + TYPE_HTML;
+	// Content types supported on a NanopubPage
+	public static final String SUPPORTED_TYPES_NANOPUB = TYPE_JELLY + "," + TYPE_TRIG + "," + TYPE_HTML;
 }


### PR DESCRIPTION
Use content type constants in NanopubPage.

Import the constants directly to reduce code clutter a bit.