### PR TITLE
Implement prometheus metrics collection and expose metrics through an endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     restart: unless-stopped
     ports:
       - 9292:9292
-      - "127.0.0.1:9293:9293" # this port should only be accessible from restricted environment as it is used for the metrics endpoint.
+      # :9293 is only accessible from localhost as it is used for the /metrics endpoint
+      - "127.0.0.1:9293:9293" 
     volumes:
       - ./setting.trig:/data/setting.trig
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     restart: unless-stopped
     ports:
       - 9292:9292
+      - "127.0.0.1:9293:9293" # this port should only be accessible from restricted environment as it is used for the metrics endpoint.
     volumes:
       - ./setting.trig:/data/setting.trig
     logging:

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 
     <main.verticle>com.knowledgepixels.registry.MainVerticle</main.verticle>
-    <launcher.class>io.vertx.core.Launcher</launcher.class>
+    <launcher.class>com.knowledgepixels.registry.ApplicationLauncher</launcher.class>
   </properties>
 
   <repositories>
@@ -65,6 +65,10 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-micrometer-metrics</artifactId>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -133,6 +137,11 @@
       <groupId>eu.ostrzyciel.jelly</groupId>
       <artifactId>jelly-rdf4j_3</artifactId>
       <version>2.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <version>1.10.13</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/knowledgepixels/registry/ApplicationLauncher.java
+++ b/src/main/java/com/knowledgepixels/registry/ApplicationLauncher.java
@@ -1,0 +1,24 @@
+package com.knowledgepixels.registry;
+
+import io.vertx.core.Launcher;
+import io.vertx.core.VertxOptions;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
+
+public class ApplicationLauncher extends Launcher {
+
+    public static void main(String[] args) {
+        new ApplicationLauncher().dispatch(args);
+    }
+
+    @Override
+    public void beforeStartingVertx(VertxOptions options) {
+        options.setMetricsOptions(
+            // Enable Micrometer metrics
+            new MicrometerMetricsOptions()
+                .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                .setJvmMetricsEnabled(true)
+                .setEnabled(true)
+        );
+    }
+}

--- a/src/main/java/com/knowledgepixels/registry/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/registry/MainVerticle.java
@@ -61,9 +61,13 @@ public class MainVerticle extends AbstractVerticle {
 		});
 
 		// Metrics
+		final var metricsHttpServer = vertx.createHttpServer();
+		final var metricsRouter = Router.router(vertx);
+		metricsHttpServer.requestHandler(metricsRouter).listen(9293);
+
 		final var metricsRegistry = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
 		final var collector = new MetricsCollector(metricsRegistry);
-		router.route("/metrics").handler(PrometheusScrapingHandler.create(metricsRegistry));
+		metricsRouter.route("/metrics").handler(PrometheusScrapingHandler.create(metricsRegistry));
 
 		router.route(HttpMethod.GET, "/*").handler(c -> {
 			MainPage.show(c);

--- a/src/main/java/com/knowledgepixels/registry/MetricsCollector.java
+++ b/src/main/java/com/knowledgepixels/registry/MetricsCollector.java
@@ -1,0 +1,103 @@
+package com.knowledgepixels.registry;
+
+import com.mongodb.client.ClientSession;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.knowledgepixels.registry.RegistryDB.*;
+
+public final class MetricsCollector {
+
+    private final AtomicInteger loadCounter = new AtomicInteger(0);
+    private final AtomicInteger trustStateCounter = new AtomicInteger(0);
+    private final AtomicInteger agentCount = new AtomicInteger(0);
+    private final AtomicInteger accountCount = new AtomicInteger(0);
+
+    private final Map<ServerStatus, AtomicInteger> statusStates = new ConcurrentHashMap<>();
+
+    public MetricsCollector(MeterRegistry meterRegistry) {
+        // Numeric metrics
+        Gauge.builder("registry.load.counter", loadCounter, AtomicInteger::get).register(meterRegistry);
+        Gauge.builder("registry.trust.state.counter", trustStateCounter, AtomicInteger::get).register(meterRegistry);
+        Gauge.builder("registry.agent.count", agentCount, AtomicInteger::get).register(meterRegistry);
+        Gauge.builder("registry.account.count", accountCount, AtomicInteger::get).register(meterRegistry);
+
+        // Status label metrics
+        for (final var status : ServerStatus.values()) {
+            AtomicInteger stateGauge = new AtomicInteger(0);
+            statusStates.put(status, stateGauge);
+            Gauge.builder("registry.server.status", stateGauge, AtomicInteger::get)
+                .description("Server status (1 if current)")
+                .tag("status", status.name())
+                .register(meterRegistry);
+        }
+    }
+
+    public void updateMetrics() {
+        try (final var session = RegistryDB.getClient().startSession()) {
+            // Update numeric metrics
+            extractMaximalIntegerValueFromField(session, "nanopubs", "counter")
+                .ifPresent(loadCounter::set);
+
+            extractIntegerValueFromField(session, "serverInfo", "trustStateCounter")
+                .ifPresent(trustStateCounter::set);
+
+            agentCount.set(countDocumentsInCollection(session, "agents"));
+            accountCount.set(countDocumentsInCollection(session, "accounts"));
+
+            // Update status gauge
+            final var currentStatus = extractStringValueFromField(session, "serverInfo", "status")
+                .map(ServerStatus::valueOf)
+                .orElse(null);
+            for (final var status : ServerStatus.values()) {
+                statusStates.get(status).set(status.equals(currentStatus) ? 1 : 0);
+            }
+        } catch (Exception e) {
+            System.err.printf("Error updating metrics: %s%n", e.getMessage());
+        }
+    }
+
+    private Optional<Integer> extractMaximalIntegerValueFromField(
+        ClientSession session,
+        String collectionName,
+        String fieldName
+    ) {
+        return Optional
+            .ofNullable(getMaxValue(session, collectionName, fieldName))
+            .filter(Number.class::isInstance)
+            .map(Number.class::cast)
+            .map(Number::intValue);
+    }
+
+    private Optional<Integer> extractIntegerValueFromField(
+        ClientSession session,
+        String collectionName,
+        String fieldName
+    ) {
+        return Optional
+            .ofNullable(getValue(session, collectionName, fieldName))
+            .filter(Number.class::isInstance)
+            .map(Number.class::cast)
+            .map(Number::intValue);
+    }
+
+    private Optional<String> extractStringValueFromField(
+        ClientSession session,
+        String collectionName,
+        String fieldName
+    ) {
+        return Optional
+            .ofNullable(getValue(session, collectionName, fieldName))
+            .filter(String.class::isInstance)
+            .map(String.class::cast);
+    }
+
+    private int countDocumentsInCollection(ClientSession session, String collectionName) {
+        return (int) collection(collectionName).countDocuments(session);
+    }
+}


### PR DESCRIPTION
This PR implements the collection and exposure of some domain-specific metrics useful for monitoring registry's state.
The following metrics are added and collected at an interval of 1 second:
- Extended JVM and system metrics
- Current application state (exposed via `registry_server_status` with 5 labeled gauges)
- Load Counter (exposed via `registry_load_counter`) 
- Trust State Counter (exposed via `registry_trust_state_counter`)
- Current Agent Count (exposed via `registry_agent_count`)
- Current Account Count (exposed via `registry_account_count`)

The metrics are exposed and served ready to consume by prometheus through the `/metrics` endpoint:
![image](https://github.com/user-attachments/assets/bd3ab1ad-5771-4cc4-91b0-f19f68de6a94)

Technical notes:
- The PR replaces standard Vertx `Launcher` with a custom `ApplicationLauncher` extension due to a requirement to configure metrics collection before Vertx is initialized.
- All metrics are collected and managed by `MetricsCollector` class