### PR TITLE
Add configurable list of registries to connect to

### DIFF
--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -5,6 +5,7 @@ services:
       - JPDA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
       - REGISTRY_COVERAGE_TYPES=all
       - REGISTRY_COVERAGE_AGENTS=viaSetting
+      - REGISTRY_PEER_URLS=https://registry.petapico.org/;https://registry.knowledgepixels.com/
 #     - REGISTRY_PERFORM_FULL_LOAD=false
 #     - REGISTRY_TEST_INSTANCE=true  # Set as test instance; only has an effect on DB initialization
 #     - REGISTRY_SETTING_FILE=/data/registry.trig

--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -82,12 +82,7 @@ public class NanopubLoader {
 			processFunction.accept(e);
 		}
 	}
-
-	private static final String[] peerUrls = new String[] {
-			"https://registry.petapico.org/",
-			"https://registry.knowledgepixels.com/",
-			"https://registry.np.trustyuri.net/"
-	};
+	private static final String[] peerUrls = Utils.getEnv("REGISTRY_PEER_URLS", Utils.DEFAULT_PEER_URLS).split(";");
 
 	public static Stream<MaybeNanopub> retrieveNanopubsFromPeers(String typeHash, String pubkeyHash) {
 		// TODO Move the code of this method to nanopub-java library.

--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -82,7 +82,10 @@ public class NanopubLoader {
 			processFunction.accept(e);
 		}
 	}
-	private static final String[] peerUrls = Utils.getEnv("REGISTRY_PEER_URLS", Utils.DEFAULT_PEER_URLS).split(";");
+
+	// Check if the environment variable REGISTRY_PEER_URLS is set, otherwise use the default peer URLs.
+	private static String envPeerUrls = Utils.getEnv("REGISTRY_PEER_URLS", "");
+	private static final String[] peerUrls = (!envPeerUrls.isEmpty())? envPeerUrls.split(";"): Utils.DEFAULT_PEER_URLS;
 
 	public static Stream<MaybeNanopub> retrieveNanopubsFromPeers(String typeHash, String pubkeyHash) {
 		// TODO Move the code of this method to nanopub-java library.

--- a/src/main/java/com/knowledgepixels/registry/Utils.java
+++ b/src/main/java/com/knowledgepixels/registry/Utils.java
@@ -139,7 +139,7 @@ public class Utils {
 			TYPE_TRIX + "," +
 			TYPE_HTML;
 
-	public static final String DEFAULT_PEER_URLS = "https://registry.petapico.org/;https://registry.knowledgepixels.com/;https://registry.np.trustyuri.net/";
+	public static final String[] DEFAULT_PEER_URLS = new String[]{"https://registry.petapico.org/", "https://registry.knowledgepixels.com/", "https://registry.np.trustyuri.net/"};
 
 	private static Map<String,String> extensionTypeMap;
 

--- a/src/main/java/com/knowledgepixels/registry/Utils.java
+++ b/src/main/java/com/knowledgepixels/registry/Utils.java
@@ -139,7 +139,11 @@ public class Utils {
 			TYPE_TRIX + "," +
 			TYPE_HTML;
 
-	public static final String[] DEFAULT_PEER_URLS = new String[]{"https://registry.petapico.org/", "https://registry.knowledgepixels.com/", "https://registry.np.trustyuri.net/"};
+	public static final String[] DEFAULT_PEER_URLS = new String[] {
+		"https://registry.petapico.org/",
+		"https://registry.knowledgepixels.com/",
+		"https://registry.np.trustyuri.net/"
+	};
 
 	private static Map<String,String> extensionTypeMap;
 

--- a/src/main/java/com/knowledgepixels/registry/Utils.java
+++ b/src/main/java/com/knowledgepixels/registry/Utils.java
@@ -139,6 +139,8 @@ public class Utils {
 			TYPE_TRIX + "," +
 			TYPE_HTML;
 
+	public static final String DEFAULT_PEER_URLS = "https://registry.petapico.org/;https://registry.knowledgepixels.com/;https://registry.np.trustyuri.net/";
+
 	private static Map<String,String> extensionTypeMap;
 
 	public static String getType(String extension) {


### PR DESCRIPTION
This PR adds the possibility to manually configure registry URLs the nanopublication registry will try to connect to through an environmental variable, `REGISTRY_PEER_URLS`. This is necessary, for instance, to connect the registry to other local instances in a Kubernetes cluster. If the variable is not supplied, the registry defaults to the previous hardcoded list. 

The changes have been tested on a local deployment.