### PR TITLE
Upgrade Jelly-JVM to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>com.github.Nanopublication</groupId>
       <artifactId>nanopub-java</artifactId>
-      <version>14309e2081083c194e99982d161ef30690e284d1</version>
+      <version>e4e430b3b5f09caa1c852e67a15a86bfc7b5a986</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>
@@ -134,9 +134,14 @@
       <version>1.82</version>
     </dependency>
     <dependency>
-      <groupId>eu.ostrzyciel.jelly</groupId>
-      <artifactId>jelly-rdf4j_3</artifactId>
-      <version>2.9.1</version>
+      <groupId>eu.neverblink.jelly</groupId>
+      <artifactId>jelly-rdf4j</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>eu.neverblink.jelly</groupId>
+      <artifactId>jelly-core-protos-google</artifactId>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/src/main/java/com/knowledgepixels/registry/ApiCache.java
+++ b/src/main/java/com/knowledgepixels/registry/ApiCache.java
@@ -1,6 +1,5 @@
 package com.knowledgepixels.registry;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -8,9 +7,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.FailedApiCallException;
 import org.nanopub.extra.services.QueryAccess;
-
-import com.opencsv.exceptions.CsvValidationException;
 
 // TODO Code copied and adjusted (made synchronous) from Nanodash; should be moved to nanopub-java at some point
 public class ApiCache {
@@ -24,7 +22,7 @@ public class ApiCache {
 	private static ApiResponse get(String queryId, Map<String,String> params) {
 		try {
 			return QueryAccess.get(queryId, params);
-		} catch (CsvValidationException | IOException ex) {
+		} catch (FailedApiCallException ex) {
 			ex.printStackTrace();
 		}
 		return null;

--- a/src/main/java/com/knowledgepixels/registry/NanopubPage.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubPage.java
@@ -19,8 +19,8 @@ import org.nanopub.NanopubUtils;
 import com.github.jsonldjava.shaded.com.google.common.base.Charsets;
 import com.mongodb.client.ClientSession;
 
-import eu.ostrzyciel.jelly.core.IoUtils$;
-import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame$;
+import eu.neverblink.jelly.core.utils.IoUtils;
+import eu.neverblink.jelly.core.proto.google.v1.RdfStreamFrame;
 import io.vertx.ext.web.RoutingContext;
 
 public class NanopubPage extends Page {
@@ -85,13 +85,13 @@ public class NanopubPage extends Page {
 					// Parse the Jelly frame and return it as Protobuf Text Format Language
 					// https://protobuf.dev/reference/protobuf/textformat-spec/
 					// It's better than bombarding the browser with a binary file.
-					var frame = RdfStreamFrame$.MODULE$.parseFrom(((Binary) npDoc.get("jelly")).getData());
-					println(frame.toProtoString());
+					var frame = RdfStreamFrame.parseFrom(((Binary) npDoc.get("jelly")).getData());
+					println(frame.toString());
 				} else {
 					// To return this correctly, we would need to prepend the delimiter byte before the Jelly frame
 					// (the DB stores is non-delimited and the HTTP response must be delimited).
 					BufferOutputStream outputStream = new BufferOutputStream();
-					IoUtils$.MODULE$.writeFrameAsDelimited(
+					IoUtils.writeFrameAsDelimited(
 							((Binary) npDoc.get("jelly")).getData(),
 							outputStream
 					);

--- a/src/main/java/com/knowledgepixels/registry/NanopubPage.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubPage.java
@@ -20,7 +20,6 @@ import com.github.jsonldjava.shaded.com.google.common.base.Charsets;
 import com.mongodb.client.ClientSession;
 
 import eu.neverblink.jelly.core.utils.IoUtils;
-import eu.neverblink.jelly.core.proto.google.v1.RdfStreamFrame;
 import io.vertx.ext.web.RoutingContext;
 
 public class NanopubPage extends Page {
@@ -85,7 +84,8 @@ public class NanopubPage extends Page {
 					// Parse the Jelly frame and return it as Protobuf Text Format Language
 					// https://protobuf.dev/reference/protobuf/textformat-spec/
 					// It's better than bombarding the browser with a binary file.
-					var frame = RdfStreamFrame.parseFrom(((Binary) npDoc.get("jelly")).getData());
+					var frame = eu.neverblink.jelly.core.proto.google.v1.RdfStreamFrame
+						.parseFrom(((Binary) npDoc.get("jelly")).getData());
 					println(frame.toString());
 				} else {
 					// To return this correctly, we would need to prepend the delimiter byte before the Jelly frame


### PR DESCRIPTION
This PR upgrades the version of Nanopubs-Java to the latest and Jelly-JVM to 3.1.0, and introduces small code adjustments to support new Jelly-JVM.
Side note: `jelly-core-protos-google` is introduced as this is a new module in Jelly-JVM that is useful for string representation of Protobuf messages.