### PR TITLE
Fix bootstrapping a Registry cluster from scratch

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -87,6 +87,13 @@ public class NanopubLoader {
 	private static String envPeerUrls = Utils.getEnv("REGISTRY_PEER_URLS", "");
 	private static final String[] peerUrls = (!envPeerUrls.isEmpty())? envPeerUrls.split(";"): Utils.DEFAULT_PEER_URLS;
 
+	/**
+	 * Retrieve Nanopubs from the peers of this Nanopub Registry.
+	 *
+	 * @param typeHash The hash of the type of the Nanopub to retrieve.
+	 * @param pubkeyHash The hash of the pubkey of the Nanopub to retrieve.
+	 * @return A stream of MaybeNanopub objects, or an empty stream if no peer is available.
+	 */
 	public static Stream<MaybeNanopub> retrieveNanopubsFromPeers(String typeHash, String pubkeyHash) {
 		// TODO Move the code of this method to nanopub-java library.
 
@@ -123,7 +130,7 @@ public class NanopubLoader {
 				ex.printStackTrace();
 			}
 		}
-		return null;
+		return Stream.empty();
 	}
 
 	public static Nanopub retrieveNanopub(ClientSession mongoSession, String nanopubId) {


### PR DESCRIPTION
Currently, if we create a cluster of Registries that are all empty, they will be unable get out of the `coreLoading` state:

<img width="512" height="277" alt="image(6)" src="https://github.com/user-attachments/assets/69594bd2-2d89-4159-8fb7-3fb67b18ffe3" />

(sorry for the awful resolution, the original got lost and I only have this)

This was due to us returning null if there were no Registries to communicate with. Here we instead use an empty stream.

While this works (tested on our test cluster), I'm not sure if this was the original intention behind the code. If the null is supposed to mean something, then we should instead add null handling code to the caller, because currently there is none.
