### PR TITLE
Use Java 25 in Docker; update Jelly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-21
+FROM maven:3.9.11-eclipse-temurin-25
 
 ENV APP_DIR /app
 ENV TMP_DIR /tmp

--- a/pom.xml
+++ b/pom.xml
@@ -136,12 +136,12 @@
     <dependency>
       <groupId>eu.neverblink.jelly</groupId>
       <artifactId>jelly-rdf4j</artifactId>
-      <version>3.1.0</version>
+      <version>3.6.2</version>
     </dependency>
     <dependency>
       <groupId>eu.neverblink.jelly</groupId>
       <artifactId>jelly-core-protos-google</artifactId>
-      <version>3.1.0</version>
+      <version>3.6.2</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>


### PR DESCRIPTION
JDK 25 brings a lot of performance improvements since JDK 21, this should give a small boost to the Registry. JDK 25 is also considered LTS.

I've also updated Jelly-JVM to 3.6.2 for the latest perf improvements and bugfixes.