### PR TITLE
feat: add registry-to-registry peer sync for CHECK_NEW

### DIFF
--- a/design.md
+++ b/design.md
@@ -105,35 +105,35 @@ Tasks are scheduled and executed sequentially from a `tasks` collection. The mai
 3. `FINISH_ITERATION` — repeats step 2 until no more changes
 4. `CALCULATE_TRUST_SCORES` → `AGGREGATE_AGENTS` → `ASSIGN_PUBKEYS` → `DETERMINE_UPDATES` → `FINALIZE_TRUST_STATE` → `RELEASE_DATA` — compute trust scores and quotas, swap in new data
 5. `UPDATE` → `LOAD_FULL` — load all nanopubs for trusted accounts
-6. `CHECK_MORE_PUBKEYS` → `RUN_OPTIONAL_LOAD` → `CHECK_NEW` — discover new pubkeys from peers, load new nanopubs, then loop back to `LOAD_FULL`
+6. `RUN_OPTIONAL_LOAD` → `CHECK_NEW` — load nanopubs for non-approved pubkeys (one per cycle), check peers for new nanopubs and discover new pubkeys, then loop back to `LOAD_FULL`
 
 See [Task.java](src/main/java/com/knowledgepixels/registry/Task.java).
 
 
 ## Updating from peers
 
-To update nanopublications from peer Nanopub Registries, the steps below are followed. A Nanopub Registry prepares itself for these updates like this:
+The `CHECK_NEW` task invokes `RegistryPeerConnector.checkPeers()`, which iterates over peer registries (in random order) and synchronizes nanopubs. Per-peer state is tracked in the `peerState` collection.
 
-- Keep a list of peer services, together with info from the last time they were visited, most importantly `setupId`, `stateCounter`, and `status`.
-- (`stateCounter` is roughly the total number of nanopublication load events that have ever occurred on this instance, including those for pubkeys that have been unloaded since; but this still needs some proper write-up/specification)
-- This list of peer services includes the services listed in the settings as well as services approved by approved agents (to be specified how this works exactly).
-- Keep info also about the specific pubkey/type lists that were visited at these peer services, most importantly the position up to which we had checked and loaded all nanopublications
+**Preparation:**
+- Track each peer's `setupId` and `loadCounter` in the `peerState` collection
+- `loadCounter` is the number of nanopub load events on the peer (increments per nanopub)
+- Peer URLs come from settings and approved agents
 
-For a registry to update its nanopublications, it iterates over the list of peer services and performs these steps on each of them:
+**Per-peer sync steps:**
 
-1. Retrieve the basic info of the chosen peer service, i.e. `setupId`, `stateCounter`, and `status`.
-2. If we have info about this peer service from an earlier request, but the `setupId` is different, this means that the service has been reset in the meantime and our previous info about it is no longer valid. So, we delete the old info and treat it as an unknown service.
-3. If `setupId` and `stateCounter` both haven't changed since our last request, then there is nothing new on this peer service, and we can abort this process and move to the next peer service.
-4. If `status` is `loading` (or other non-ready status; to be specified), we ignore this instance for now and abort this process and move to the next peer service.
-5. If `stateCounter` has increased since the last request but only by a relatively small amount (given by a threshold value still to be determined, e.g. 100 or 1000), request these nanopublications and load them to the respective lists. Then we abort this process and move to the next peer service.
-6. If `stateCounter` has increased by more, we iterate over all our pubkeys to ask the peer service about them.
-7. Retrieve info about the specific pubkey list (with type = `$` standing for "all types"; more specific algorithms to be determined for the cases where services store only certain types), most importantly the maximum position (= size of list) and the overall checksum
-8. If our list has the same checksum (and therefore same size), there is nothing new and we can move on with checking the next pubkey.
-9. We calculate the maximum number of unknown nanopublications in the peer list, taking into account the info we have from any previous request (e.g. if the peer list has size 13, and we had checked the nanopublications up to position 5 the last time, then the maximum number of unknown nanopublications is 8)
-10. If the maximum number of unknown nanopublications is small enough (given by a threshold value still to be determined, e.g. 100 or 1000), we request all nanopublications after the last position one by one, and add unknown ones to our list too.
-11. If the maximum number of unknown nanopublications is larger, then we try to find a position up to which both lists have identical nanopublications by checking whether checksums we have in our list occur in the peer list too (this can be done with individual requests or bulk ones of e.g. 100 checksums; to be defined)
-12. If we find a match, we update our position up to which we know that all nanopublications are loaded to the found position. If the maximum number of unknown nanopublications is now small enough, we load the nanopublications one by one as for Step 5.
-13. If we don't find a matching checksum or the maximum number of unknown nanopublications is still too large, we check a defined number of positions at the peer list, but then stop and leave this for later. The idea is that we are hoping that we have better luck at other peers loading the missing nanopublications (because they might have ordered them in a way that is more similar to our lists, thereby increasing the chances of identical checksums).
+1. Fetch peer info (`.json` endpoint) to get `setupId`, `loadCounter`, and `status`.
+2. Skip peers with non-ready status (only `ready` and `updating` are accepted).
+3. If `setupId` changed since last check, delete stored peer state and treat as new.
+4. If `loadCounter` is unchanged, skip (nothing new).
+5. **Small delta** (loadCounter difference < 100): fetch recent nanopubs via `/nanopubs.jelly?afterCounter=X`.
+6. **Large delta** (or first sync): iterate over approved pubkeys and download their `$.jelly` lists from the peer. Only pubkeys with loaded `$` lists are processed.
+7. **Discover pubkeys**: fetch `/pubkeys.json` from the peer and create `encountered` intro lists for any unknown pubkeys, so they can be loaded later via `RUN_OPTIONAL_LOAD`.
+8. Update peer state with current `setupId` and `loadCounter`.
+
+**Not yet implemented optimizations:**
+- Per-pubkey/type position tracking for incremental sync (currently downloads full lists)
+- Checksum-based binary search to avoid downloading full lists when only a few nanopubs are new
+- Throttled loading for non-approved pubkeys during peer sync
 
 
 ## Data Structure
@@ -199,6 +199,9 @@ Field type legend: primary# / unique* / combined-unique** / indexed^ (all with p
       { id#:'SueRich>b55 JohnDoe>a83', depth^:2, agent^:JohnDoe, pubkey^:a83, ratio:0.009 }
       { id#:'BillSmith>d32 JoeBold>e83 AmyBaker>f02 JohnDoe>a83', depth^:4, agent^:JohnDoe, pubkey^:a83, ratio:0.00007 }
       { id#:'JohnDoe>d28', depth^:1, agent^:JohnDoe, pubkey^:d28, ratio:0.01 }
+      ...
+    peerState:
+      { id#:'https://example.com/peer/', setupId:1332309348, loadCounter:42000, lastChecked:1710672000000 }
       ...
     tasks:
       { notBefore^:1710672000000, action^:CHECK_NEW }

--- a/design.md
+++ b/design.md
@@ -104,8 +104,8 @@ Tasks are scheduled and executed sequentially from a `tasks` collection. The mai
 2. `LOAD_DECLARATIONS` → `EXPAND_TRUST_PATHS` → `LOAD_CORE` — iteratively load core nanopubs and build the trust network
 3. `FINISH_ITERATION` — repeats step 2 until no more changes
 4. `CALCULATE_TRUST_SCORES` → `AGGREGATE_AGENTS` → `ASSIGN_PUBKEYS` → `DETERMINE_UPDATES` → `FINALIZE_TRUST_STATE` → `RELEASE_DATA` — compute trust scores and quotas, swap in new data
-5. `UPDATE` → `LOAD_FULL` — load all nanopubs for trusted accounts
-6. `RUN_OPTIONAL_LOAD` → `CHECK_NEW` — load nanopubs for non-approved pubkeys (one per cycle), check peers for new nanopubs and discover new pubkeys, then loop back to `LOAD_FULL`
+5. `LOAD_FULL` → `RUN_OPTIONAL_LOAD` → `CHECK_NEW` — continuous cycle: load nanopubs for trusted accounts, then optionally load for non-approved pubkeys (one per cycle), then check peers for new nanopubs and discover new pubkeys, then loop back to `LOAD_FULL`
+6. `UPDATE` (hourly) → `INIT_COLLECTIONS` — triggers a trust state recalculation (steps 2–4); the `LOAD_FULL` cycle (step 5) continues running during updates
 
 See [Task.java](src/main/java/com/knowledgepixels/registry/Task.java).
 
@@ -116,19 +116,20 @@ The `CHECK_NEW` task invokes `RegistryPeerConnector.checkPeers()`, which iterate
 
 **Preparation:**
 - Track each peer's `setupId` and `loadCounter` in the `peerState` collection
-- `loadCounter` is the number of nanopub load events on the peer (increments per nanopub)
-- Peer URLs come from settings and approved agents
+- `loadCounter` is the maximum counter value from the peer's nanopubs collection (increments per nanopub loaded)
+- Peer URLs come from the `REGISTRY_PEER_URLS` environment variable
 
 **Per-peer sync steps:**
 
-1. Fetch peer info (`.json` endpoint) to get `setupId`, `loadCounter`, and `status`.
+1. Send HTTP HEAD request to peer URL; extract `Nanopub-Registry-Status`, `Nanopub-Registry-Setup-Id`, and `Nanopub-Registry-Load-Counter` from response headers.
 2. Skip peers with non-ready status (only `ready` and `updating` are accepted).
 3. If `setupId` changed since last check, delete stored peer state and treat as new.
 4. If `loadCounter` is unchanged, skip (nothing new).
 5. **Small delta** (loadCounter difference < 100): fetch recent nanopubs via `/nanopubs.jelly?afterCounter=X`.
 6. **Large delta** (or first sync): iterate over approved pubkeys and download their `$.jelly` lists from the peer. Only pubkeys with loaded `$` lists are processed.
-7. **Discover pubkeys**: fetch `/pubkeys.json` from the peer and create `encountered` intro lists for any unknown pubkeys, so they can be loaded later via `RUN_OPTIONAL_LOAD`.
-8. Update peer state with current `setupId` and `loadCounter`.
+7. **Full fetch** (once per peer): if `fullFetchDone` is not set, fetch all nanopubs via `/nanopubs.jelly` using a dedicated session to avoid transaction timeouts.
+8. **Discover pubkeys**: fetch `/pubkeys.json` from the peer and create `encountered` intro lists for any unknown pubkeys, so they can be loaded later via `RUN_OPTIONAL_LOAD`.
+9. Update peer state with current `setupId`, `loadCounter`, and `fullFetchDone`.
 
 **Not yet implemented optimizations:**
 - Per-pubkey/type position tracking for incremental sync (currently downloads full lists)
@@ -201,7 +202,7 @@ Field type legend: primary# / unique* / combined-unique** / indexed^ (all with p
       { id#:'JohnDoe>d28', depth^:1, agent^:JohnDoe, pubkey^:d28, ratio:0.01 }
       ...
     peerState:
-      { id#:'https://example.com/peer/', setupId:1332309348, loadCounter:42000, lastChecked:1710672000000 }
+      { id#:'https://example.com/peer/', setupId:1332309348, loadCounter:42000, fullFetchDone:true, lastChecked:1710672000000 }
       ...
     tasks:
       { notBefore^:1710672000000, action^:CHECK_NEW }

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,18 @@
         <version>${maven-surefire-plugin.version}</version>
       </plugin>
       <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>${exec-maven-plugin.version}</version>

--- a/src/main/java/com/knowledgepixels/registry/Collection.java
+++ b/src/main/java/com/knowledgepixels/registry/Collection.java
@@ -8,7 +8,8 @@ public enum Collection {
     ACCOUNTS("accounts"),
     NANOPUBS("nanopubs"),
 
-    TASKS("tasks");
+    TASKS("tasks"),
+    PEER_STATE("peerState");
 
     private final String value;
 

--- a/src/main/java/com/knowledgepixels/registry/DebugPage.java
+++ b/src/main/java/com/knowledgepixels/registry/DebugPage.java
@@ -56,6 +56,7 @@ public class DebugPage extends Page {
                 println(d.getString("agent") + ">" + d.get("pubkey") + " " + d.get("depth") + " (" + d.get("status") + ")");
             }
         } else if (getRequestString().matches("/debug/peerState")) {
+            setRespContentType("text/plain");
             try {
                 long count = collection(Collection.PEER_STATE.toString()).countDocuments(mongoSession);
                 println("peerState documents: " + count);
@@ -66,7 +67,6 @@ public class DebugPage extends Page {
             } catch (Exception ex) {
                 println("Error: " + ex.getClass().getName() + ": " + ex.getMessage());
             }
-            setRespContentType("text/plain");
         } else {
             c.response().setStatusCode(400).setStatusMessage("Invalid request: " + getFullRequest());
         }

--- a/src/main/java/com/knowledgepixels/registry/DebugPage.java
+++ b/src/main/java/com/knowledgepixels/registry/DebugPage.java
@@ -56,15 +56,15 @@ public class DebugPage extends Page {
                 println(d.getString("agent") + ">" + d.get("pubkey") + " " + d.get("depth") + " (" + d.get("status") + ")");
             }
         } else if (getRequestString().matches("/debug/peerState")) {
-            MongoCursor<Document> ps = collection(Collection.PEER_STATE.toString()).find(mongoSession).cursor();
-            while (ps.hasNext()) {
-                Document d = ps.next();
-                println(d.get("_id")
-                        + " setupId=" + d.get("setupId")
-                        + " loadCounter=" + d.get("loadCounter")
-                        + " fullFetchDone=" + d.get("fullFetchDone")
-                        + " fullFetchPosition=" + d.get("fullFetchPosition")
-                        + " lastChecked=" + d.get("lastChecked"));
+            try {
+                long count = collection(Collection.PEER_STATE.toString()).countDocuments(mongoSession);
+                println("peerState documents: " + count);
+                MongoCursor<Document> ps = collection(Collection.PEER_STATE.toString()).find(mongoSession).cursor();
+                while (ps.hasNext()) {
+                    println(ps.next().toJson());
+                }
+            } catch (Exception ex) {
+                println("Error: " + ex.getClass().getName() + ": " + ex.getMessage());
             }
             setRespContentType("text/plain");
         } else {

--- a/src/main/java/com/knowledgepixels/registry/DebugPage.java
+++ b/src/main/java/com/knowledgepixels/registry/DebugPage.java
@@ -59,12 +59,12 @@ public class DebugPage extends Page {
             MongoCursor<Document> ps = collection(Collection.PEER_STATE.toString()).find(mongoSession).cursor();
             while (ps.hasNext()) {
                 Document d = ps.next();
-                println(d.getString("_id")
-                        + " setupId=" + d.getLong("setupId")
-                        + " loadCounter=" + d.getLong("loadCounter")
-                        + " fullFetchDone=" + d.getBoolean("fullFetchDone")
-                        + " fullFetchPosition=" + d.getLong("fullFetchPosition")
-                        + " lastChecked=" + d.getLong("lastChecked"));
+                println(d.get("_id")
+                        + " setupId=" + d.get("setupId")
+                        + " loadCounter=" + d.get("loadCounter")
+                        + " fullFetchDone=" + d.get("fullFetchDone")
+                        + " fullFetchPosition=" + d.get("fullFetchPosition")
+                        + " lastChecked=" + d.get("lastChecked"));
             }
             setRespContentType("text/plain");
         } else {

--- a/src/main/java/com/knowledgepixels/registry/DebugPage.java
+++ b/src/main/java/com/knowledgepixels/registry/DebugPage.java
@@ -55,6 +55,18 @@ public class DebugPage extends Page {
                 Document d = tp.next();
                 println(d.getString("agent") + ">" + d.get("pubkey") + " " + d.get("depth") + " (" + d.get("status") + ")");
             }
+        } else if (getRequestString().matches("/debug/peerState")) {
+            MongoCursor<Document> ps = collection(Collection.PEER_STATE.toString()).find(mongoSession).cursor();
+            while (ps.hasNext()) {
+                Document d = ps.next();
+                println(d.getString("_id")
+                        + " setupId=" + d.getLong("setupId")
+                        + " loadCounter=" + d.getLong("loadCounter")
+                        + " fullFetchDone=" + d.getBoolean("fullFetchDone")
+                        + " fullFetchPosition=" + d.getLong("fullFetchPosition")
+                        + " lastChecked=" + d.getLong("lastChecked"));
+            }
+            setRespContentType("text/plain");
         } else {
             c.response().setStatusCode(400).setStatusMessage("Invalid request: " + getFullRequest());
         }

--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.registry;
 
+import com.mongodb.ErrorCategory;
 import com.mongodb.MongoWriteException;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCursor;
@@ -77,7 +78,7 @@ public class NanopubLoader {
                         .append("type", INTRO_TYPE_HASH)
                         .append("status", EntryStatus.encountered.getValue()));
             } catch (MongoWriteException e) {
-                if (e.getError().getCode() != 11000) throw e;
+                if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
             }
         }
     }

--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static com.knowledgepixels.registry.RegistryDB.has;
+import static com.knowledgepixels.registry.RegistryDB.insert;
 
 public class NanopubLoader {
 
@@ -68,6 +69,11 @@ public class NanopubLoader {
             RegistryDB.loadNanopub(mongoSession, np, pubkeyHash, "$");
         } else if (has(mongoSession, "lists", new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH).append("status", "loaded"))) {
             RegistryDB.loadNanopub(mongoSession, np, pubkeyHash, INTRO_TYPE, ENDORSE_TYPE);
+        } else if (!has(mongoSession, "lists", new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH))) {
+            // Unknown pubkey: create encountered intro list so RUN_OPTIONAL_LOAD picks it up
+            insert(mongoSession, "lists", new Document("pubkey", pubkeyHash)
+                    .append("type", INTRO_TYPE_HASH)
+                    .append("status", EntryStatus.encountered.getValue()));
         }
     }
 

--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.registry;
 
+import com.mongodb.MongoWriteException;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCursor;
 import net.trustyuri.TrustyUriUtils;
@@ -71,9 +72,13 @@ public class NanopubLoader {
             RegistryDB.loadNanopub(mongoSession, np, pubkeyHash, INTRO_TYPE, ENDORSE_TYPE);
         } else if (!has(mongoSession, "lists", new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH))) {
             // Unknown pubkey: create encountered intro list so RUN_OPTIONAL_LOAD picks it up
-            insert(mongoSession, "lists", new Document("pubkey", pubkeyHash)
-                    .append("type", INTRO_TYPE_HASH)
-                    .append("status", EntryStatus.encountered.getValue()));
+            try {
+                insert(mongoSession, "lists", new Document("pubkey", pubkeyHash)
+                        .append("type", INTRO_TYPE_HASH)
+                        .append("status", EntryStatus.encountered.getValue()));
+            } catch (MongoWriteException e) {
+                if (e.getError().getCode() != 11000) throw e;
+            }
         }
     }
 

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -377,7 +377,7 @@ public class RegistryDB {
             return false;
         }
         if (has(mongoSession, Collection.NANOPUBS.toString(), ac)) {
-            logger.info("Already loaded: {}", nanopub.getUri());
+            logger.debug("Already loaded: {}", nanopub.getUri());
         } else {
             Long counter = (Long) getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "counter");
             if (counter == null) counter = 0l;
@@ -455,7 +455,7 @@ public class RegistryDB {
         }
 
         if (has(mongoSession, "listEntries", new Document("pubkey", pubkeyHash).append("type", typeHash).append("np", ac))) {
-            logger.info("Already listed: {}", nanopub.getUri());
+            logger.debug("Already listed: {}", nanopub.getUri());
         } else {
 
             Document doc = getMaxValueDocument(mongoSession, "listEntries", new Document("pubkey", pubkeyHash).append("type", typeHash), "position");

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -3,6 +3,7 @@ package com.knowledgepixels.registry;
 import com.knowledgepixels.registry.db.IndexInitializer;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoNamespace;
+import com.mongodb.ErrorCategory;
 import com.mongodb.MongoWriteException;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.ClientSession;
@@ -310,7 +311,7 @@ public class RegistryDB {
             insert(mongoSession, "hashes", new Document("value", value).append("hash", Utils.getHash(value)));
         } catch (MongoWriteException e) {
             // Duplicate key error -- ignore it
-            if (e.getError().getCode() != 11000) throw e;
+            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
         }
     }
 
@@ -450,7 +451,7 @@ public class RegistryDB {
             insert(mongoSession, "lists", new Document("pubkey", pubkeyHash).append("type", typeHash));
         } catch (MongoWriteException e) {
             // Duplicate key error -- ignore it
-            if (e.getError().getCode() != 11000) throw e;
+            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
         }
 
         if (has(mongoSession, "listEntries", new Document("pubkey", pubkeyHash).append("type", typeHash).append("np", ac))) {

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -1,11 +1,10 @@
 package com.knowledgepixels.registry;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCursor;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
 import org.apache.http.util.EntityUtils;
 import org.bson.Document;
 import org.nanopub.NanopubUtils;
@@ -29,7 +28,6 @@ public class RegistryPeerConnector {
     private RegistryPeerConnector() {}
 
     private static final Logger log = LoggerFactory.getLogger(RegistryPeerConnector.class);
-    private static final Gson gson = new Gson();
     static final int SMALL_DELTA_THRESHOLD = 100;
 
     public static void checkPeers(ClientSession s) {
@@ -48,19 +46,24 @@ public class RegistryPeerConnector {
     static void checkPeer(ClientSession s, String peerUrl) throws IOException {
         log.info("Checking peer: {}", peerUrl);
 
-        JsonObject peerInfo = fetchPeerInfo(peerUrl);
-        if (peerInfo == null) return;
+        HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpHead(peerUrl));
+        int httpStatus = resp.getStatusLine().getStatusCode();
+        EntityUtils.consumeQuietly(resp.getEntity());
+        if (httpStatus < 200 || httpStatus >= 300) {
+            log.info("Failed to reach peer {}: {}", peerUrl, httpStatus);
+            return;
+        }
 
-        String status = getJsonString(peerInfo, "status");
+        String status = getHeader(resp, "Nanopub-Registry-Status");
         if (!"ready".equals(status) && !"updating".equals(status)) {
             log.info("Peer {} in non-ready state: {}", peerUrl, status);
             return;
         }
 
-        Long peerSetupId = getJsonLong(peerInfo, "setupId");
-        Long peerLoadCounter = getJsonLong(peerInfo, "loadCounter");
+        Long peerSetupId = getHeaderLong(resp, "Nanopub-Registry-Setup-Id");
+        Long peerLoadCounter = getHeaderLong(resp, "Nanopub-Registry-Load-Counter");
         if (peerSetupId == null || peerLoadCounter == null) {
-            log.info("Peer {} missing setupId or loadCounter", peerUrl);
+            log.info("Peer {} missing setupId or loadCounter headers", peerUrl);
             return;
         }
 
@@ -222,24 +225,6 @@ public class RegistryPeerConnector {
         return pubkeys;
     }
 
-    static JsonObject fetchPeerInfo(String peerUrl) {
-        String requestUrl = peerUrl + ".json";
-        try {
-            HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(requestUrl));
-            int httpStatus = resp.getStatusLine().getStatusCode();
-            if (httpStatus < 200 || httpStatus >= 300) {
-                EntityUtils.consumeQuietly(resp.getEntity());
-                log.info("Failed to fetch peer info from {}: {}", peerUrl, httpStatus);
-                return null;
-            }
-            String body = EntityUtils.toString(resp.getEntity());
-            return gson.fromJson(body, JsonObject.class);
-        } catch (IOException ex) {
-            log.info("Failed to connect to peer {}: {}", peerUrl, ex.getMessage());
-            return null;
-        }
-    }
-
     static Document getPeerState(ClientSession s, String peerUrl) {
         try (MongoCursor<Document> cursor = collection(Collection.PEER_STATE.toString())
                 .find(s, new Document("_id", peerUrl)).cursor()) {
@@ -262,12 +247,18 @@ public class RegistryPeerConnector {
         collection(Collection.PEER_STATE.toString()).deleteOne(s, new Document("_id", peerUrl));
     }
 
-    static String getJsonString(JsonObject obj, String key) {
-        return obj.has(key) && !obj.get(key).isJsonNull() ? obj.get(key).getAsString() : null;
+    static String getHeader(HttpResponse resp, String name) {
+        return resp.getFirstHeader(name) != null ? resp.getFirstHeader(name).getValue() : null;
     }
 
-    static Long getJsonLong(JsonObject obj, String key) {
-        return obj.has(key) && !obj.get(key).isJsonNull() ? obj.get(key).getAsLong() : null;
+    static Long getHeaderLong(HttpResponse resp, String name) {
+        String value = getHeader(resp, name);
+        if (value == null || "null".equals(value)) return null;
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -115,6 +115,7 @@ public class RegistryPeerConnector {
         String requestUrl = peerUrl + "nanopubs.jelly?afterCounter=" + afterCounter;
         log.info("Full fetch of all nanopubs from: {} (resuming after counter {})", requestUrl, afterCounter);
         AtomicLong lastCounter = new AtomicLong(afterCounter);
+        AtomicLong processedCount = new AtomicLong(0);
         boolean completed = false;
         try {
             HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(requestUrl));
@@ -136,6 +137,10 @@ public class RegistryPeerConnector {
                     }
                     if (m.getCounter() > 0) {
                         lastCounter.set(m.getCounter());
+                    }
+                    long count = processedCount.incrementAndGet();
+                    if (count % 1000 == 0) {
+                        log.info("Full fetch progress: {} nanopubs processed (counter: {})", count, lastCounter.get());
                     }
                 });
             }

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -96,10 +96,10 @@ public class RegistryPeerConnector {
             }
         }
 
-        // TODO Enable one-time full fetch for non-approved pubkey nanopubs:
-        // if (!Boolean.TRUE.equals(fullFetchDone)) {
-        //     loadAllNanopubs(s, peerUrl);
-        // }
+        // TODO Remove full fetch once incremental sync covers all nanopubs (including non-approved pubkeys)
+        if (!Boolean.TRUE.equals(fullFetchDone)) {
+            loadAllNanopubs(s, peerUrl);
+        }
 
         discoverPubkeys(s, peerUrl);
         updatePeerState(s, peerUrl, peerSetupId, peerLoadCounter);
@@ -116,10 +116,13 @@ public class RegistryPeerConnector {
                 log.info("Request failed: {} {}", requestUrl, httpStatus);
                 return;
             }
-            try (InputStream is = resp.getEntity().getContent()) {
+            // Use a dedicated session outside any wrapping transaction to avoid
+            // MongoDB transaction timeout on large streams.
+            try (InputStream is = resp.getEntity().getContent();
+                 ClientSession loadSession = RegistryDB.getClient().startSession()) {
                 NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
                     if (m.isSuccess()) {
-                        NanopubLoader.simpleLoad(s, m.getNanopub());
+                        NanopubLoader.simpleLoad(loadSession, m.getNanopub());
                     }
                 });
             }

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -100,15 +100,16 @@ public class RegistryPeerConnector {
         }
 
         // TODO Remove full fetch once incremental sync covers all nanopubs (including non-approved pubkeys)
-        if (!Boolean.TRUE.equals(fullFetchDone)) {
-            loadAllNanopubs(s, peerUrl);
+        boolean fullFetchSucceeded = fullFetchDone != null && fullFetchDone;
+        if (!fullFetchSucceeded) {
+            fullFetchSucceeded = loadAllNanopubs(s, peerUrl);
         }
 
         discoverPubkeys(s, peerUrl);
-        updatePeerState(s, peerUrl, peerSetupId, peerLoadCounter);
+        updatePeerState(s, peerUrl, peerSetupId, peerLoadCounter, fullFetchSucceeded);
     }
 
-    private static void loadAllNanopubs(ClientSession s, String peerUrl) {
+    private static boolean loadAllNanopubs(ClientSession s, String peerUrl) {
         String requestUrl = peerUrl + "nanopubs.jelly";
         log.info("Full fetch of all nanopubs from: {}", requestUrl);
         try {
@@ -117,7 +118,7 @@ public class RegistryPeerConnector {
             if (httpStatus < 200 || httpStatus >= 300) {
                 EntityUtils.consumeQuietly(resp.getEntity());
                 log.info("Request failed: {} {}", requestUrl, httpStatus);
-                return;
+                return false;
             }
             // Use a dedicated session outside any wrapping transaction to avoid
             // MongoDB transaction timeout on large streams.
@@ -129,8 +130,10 @@ public class RegistryPeerConnector {
                     }
                 });
             }
+            return true;
         } catch (IOException ex) {
             log.info("Failed to fetch all nanopubs from {}: {}", peerUrl, ex.getMessage());
+            return false;
         }
     }
 
@@ -232,13 +235,13 @@ public class RegistryPeerConnector {
         }
     }
 
-    static void updatePeerState(ClientSession s, String peerUrl, long setupId, long loadCounter) {
+    static void updatePeerState(ClientSession s, String peerUrl, long setupId, long loadCounter, boolean fullFetchDone) {
         collection(Collection.PEER_STATE.toString()).updateOne(s,
                 new Document("_id", peerUrl),
                 new Document("$set", new Document("_id", peerUrl)
                         .append("setupId", setupId)
                         .append("loadCounter", loadCounter)
-                        .append("fullFetchDone", true)
+                        .append("fullFetchDone", fullFetchDone)
                         .append("lastChecked", System.currentTimeMillis())),
                 new com.mongodb.client.model.UpdateOptions().upsert(true));
     }

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -32,7 +32,6 @@ public class RegistryPeerConnector {
     private RegistryPeerConnector() {}
 
     private static final Logger log = LoggerFactory.getLogger(RegistryPeerConnector.class);
-    static final int SMALL_DELTA_THRESHOLD = 100;
 
     public static void checkPeers(ClientSession s) {
         List<String> peerUrls = new ArrayList<>(Utils.getPeerUrls());
@@ -89,18 +88,15 @@ public class RegistryPeerConnector {
 
         if (lastLoadCounter != null && lastLoadCounter.equals(peerLoadCounter)) {
             log.info("Peer {} has no new nanopubs (loadCounter unchanged: {})", peerUrl, peerLoadCounter);
+        } else if (lastLoadCounter != null) {
+            // Fetch all nanopubs added since our last known position.
+            // This works for any delta size; the full fetch covers the first-sync case.
+            // TODO Add per-pubkey afterCounter tracking for more targeted incremental sync
+            long delta = peerLoadCounter - lastLoadCounter;
+            log.info("Peer {} has {} new nanopubs, fetching recent", peerUrl, delta);
+            loadRecentNanopubs(s, peerUrl, lastLoadCounter);
         } else {
-            long delta = (lastLoadCounter != null) ? peerLoadCounter - lastLoadCounter : Long.MAX_VALUE;
-
-            if (delta > 0 && delta < SMALL_DELTA_THRESHOLD) {
-                log.info("Peer {} has small delta ({}), fetching recent nanopubs", peerUrl, delta);
-                loadRecentNanopubs(s, peerUrl, lastLoadCounter);
-            } else {
-                log.info("Peer {} has large delta, checking per-pubkey lists", peerUrl);
-                // TODO Add per-pubkey/type position tracking for more efficient incremental sync
-                // TODO Add checksum-based binary search to avoid downloading full lists
-                loadByApprovedPubkeys(s, peerUrl);
-            }
+            log.info("Peer {} is new, full fetch will handle initial sync", peerUrl);
         }
 
         // TODO Remove full fetch once incremental sync covers all nanopubs (including non-approved pubkeys)
@@ -188,40 +184,6 @@ public class RegistryPeerConnector {
         }
     }
 
-    static void loadByApprovedPubkeys(ClientSession s, String peerUrl) {
-        // Only process approved pubkeys (those with loaded "$" lists)
-        // TODO Add throttled loading for non-approved pubkeys
-        List<String> approvedPubkeys = getApprovedPubkeys(s);
-        log.info("Checking {} approved pubkeys at peer {}", approvedPubkeys.size(), peerUrl);
-
-        for (String pubkeyHash : approvedPubkeys) {
-            String requestUrl = peerUrl + "list/" + pubkeyHash + "/$.jelly";
-            log.info("Fetching list from: {}", requestUrl);
-            try {
-                HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(requestUrl));
-                int httpStatus = resp.getStatusLine().getStatusCode();
-                if (httpStatus < 200 || httpStatus >= 300) {
-                    EntityUtils.consumeQuietly(resp.getEntity());
-                    if (httpStatus != 404) {
-                        log.info("Request failed: {} {}", requestUrl, httpStatus);
-                    }
-                    continue;
-                }
-                try (InputStream is = resp.getEntity().getContent()) {
-                    NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
-                        if (m.isSuccess()) {
-                            Nanopub np = m.getNanopub();
-                            RegistryDB.loadNanopub(s, np);
-                            NanopubLoader.simpleLoad(s, np);
-                        }
-                    });
-                }
-            } catch (IOException ex) {
-                log.info("Failed to fetch list from {}: {}", requestUrl, ex.getMessage());
-            }
-        }
-    }
-
     static void discoverPubkeys(ClientSession s, String peerUrl) {
         log.info("Discovering pubkeys from peer: {}", peerUrl);
         try {
@@ -249,17 +211,6 @@ public class RegistryPeerConnector {
         } catch (Exception ex) {
             log.info("Failed to discover pubkeys from {}: {}", peerUrl, ex.getMessage());
         }
-    }
-
-    static List<String> getApprovedPubkeys(ClientSession s) {
-        List<String> pubkeys = new ArrayList<>();
-        try (MongoCursor<Document> cursor = collection("lists").find(s,
-                new Document("type", "$").append("status", "loaded")).cursor()) {
-            while (cursor.hasNext()) {
-                pubkeys.add(cursor.next().getString("pubkey"));
-            }
-        }
-        return pubkeys;
     }
 
     static Document getPeerState(ClientSession s, String peerUrl) {

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -9,6 +9,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.util.EntityUtils;
 import org.bson.Document;
+import org.nanopub.Nanopub;
 import org.nanopub.NanopubUtils;
 import org.nanopub.jelly.NanopubStream;
 import org.slf4j.Logger;
@@ -128,7 +129,9 @@ public class RegistryPeerConnector {
                  ClientSession loadSession = RegistryDB.getClient().startSession()) {
                 NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
                     if (m.isSuccess()) {
-                        NanopubLoader.simpleLoad(loadSession, m.getNanopub());
+                        Nanopub np = m.getNanopub();
+                        RegistryDB.loadNanopub(loadSession, np);
+                        NanopubLoader.simpleLoad(loadSession, np);
                     }
                 });
             }
@@ -153,7 +156,9 @@ public class RegistryPeerConnector {
             try (InputStream is = resp.getEntity().getContent()) {
                 NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
                     if (m.isSuccess()) {
-                        NanopubLoader.simpleLoad(s, m.getNanopub());
+                        Nanopub np = m.getNanopub();
+                        RegistryDB.loadNanopub(s, np);
+                        NanopubLoader.simpleLoad(s, np);
                     }
                 });
             }
@@ -184,7 +189,9 @@ public class RegistryPeerConnector {
                 try (InputStream is = resp.getEntity().getContent()) {
                     NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
                         if (m.isSuccess()) {
-                            NanopubLoader.simpleLoad(s, m.getNanopub());
+                            Nanopub np = m.getNanopub();
+                            RegistryDB.loadNanopub(s, np);
+                            NanopubLoader.simpleLoad(s, np);
                         }
                     });
                 }

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.knowledgepixels.registry.RegistryDB.*;
 
@@ -105,16 +106,20 @@ public class RegistryPeerConnector {
         // TODO Remove full fetch once incremental sync covers all nanopubs (including non-approved pubkeys)
         boolean fullFetchSucceeded = fullFetchDone != null && fullFetchDone;
         if (!fullFetchSucceeded) {
-            fullFetchSucceeded = loadAllNanopubs(s, peerUrl);
+            Long fullFetchPosition = peerState != null ? peerState.getLong("fullFetchPosition") : null;
+            long afterCounter = fullFetchPosition != null ? fullFetchPosition : -1;
+            fullFetchSucceeded = loadAllNanopubs(s, peerUrl, afterCounter);
         }
 
         discoverPubkeys(s, peerUrl);
         updatePeerState(s, peerUrl, peerSetupId, peerLoadCounter, fullFetchSucceeded);
     }
 
-    private static boolean loadAllNanopubs(ClientSession s, String peerUrl) {
-        String requestUrl = peerUrl + "nanopubs.jelly";
-        log.info("Full fetch of all nanopubs from: {}", requestUrl);
+    private static boolean loadAllNanopubs(ClientSession s, String peerUrl, long afterCounter) {
+        String requestUrl = peerUrl + "nanopubs.jelly?afterCounter=" + afterCounter;
+        log.info("Full fetch of all nanopubs from: {} (resuming after counter {})", requestUrl, afterCounter);
+        AtomicLong lastCounter = new AtomicLong(afterCounter);
+        boolean completed = false;
         try {
             HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(requestUrl));
             int httpStatus = resp.getStatusLine().getStatusCode();
@@ -133,13 +138,29 @@ public class RegistryPeerConnector {
                         RegistryDB.loadNanopub(loadSession, np);
                         NanopubLoader.simpleLoad(loadSession, np);
                     }
+                    if (m.getCounter() > 0) {
+                        lastCounter.set(m.getCounter());
+                    }
                 });
             }
+            completed = true;
             return true;
         } catch (IOException ex) {
             log.info("Failed to fetch all nanopubs from {}: {}", peerUrl, ex.getMessage());
             return false;
+        } finally {
+            if (!completed && lastCounter.get() > afterCounter) {
+                log.info("Full fetch interrupted at counter {}; saving position for resume", lastCounter.get());
+                saveFullFetchPosition(s, peerUrl, lastCounter.get());
+            }
         }
+    }
+
+    private static void saveFullFetchPosition(ClientSession s, String peerUrl, long position) {
+        collection(Collection.PEER_STATE.toString()).updateOne(s,
+                new Document("_id", peerUrl),
+                new Document("$set", new Document("fullFetchPosition", position)),
+                new com.mongodb.client.model.UpdateOptions().upsert(true));
     }
 
     private static void loadRecentNanopubs(ClientSession s, String peerUrl, long afterCounter) {

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.registry;
 
+import com.mongodb.MongoWriteException;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCursor;
 import org.apache.http.HttpResponse;
@@ -200,9 +201,13 @@ public class RegistryPeerConnector {
             for (String pubkeyHash : peerPubkeys) {
                 Document filter = new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH);
                 if (!has(s, "lists", filter)) {
-                    insert(s, "lists", new Document("pubkey", pubkeyHash)
-                            .append("type", NanopubLoader.INTRO_TYPE_HASH)
-                            .append("status", EntryStatus.encountered.getValue()));
+                    try {
+                        insert(s, "lists", new Document("pubkey", pubkeyHash)
+                                .append("type", NanopubLoader.INTRO_TYPE_HASH)
+                                .append("status", EntryStatus.encountered.getValue()));
+                    } catch (MongoWriteException e) {
+                        if (e.getError().getCode() != 11000) throw e;
+                    }
                     discovered++;
                 } else if (!has(s, "lists", new Document(filter).append("status", EntryStatus.loaded.getValue()))) {
                     // Set status to encountered if not already loaded (fixes null-status entries from older code)

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -1,0 +1,270 @@
+package com.knowledgepixels.registry;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoCursor;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.bson.Document;
+import org.nanopub.NanopubUtils;
+import org.nanopub.jelly.NanopubStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.knowledgepixels.registry.RegistryDB.*;
+
+/**
+ * Checks peer Nanopub Registries for new nanopublications and loads them.
+ */
+public class RegistryPeerConnector {
+
+    private RegistryPeerConnector() {}
+
+    private static final Logger log = LoggerFactory.getLogger(RegistryPeerConnector.class);
+    private static final Gson gson = new Gson();
+    static final int SMALL_DELTA_THRESHOLD = 100;
+
+    public static void checkPeers(ClientSession s) {
+        List<String> peerUrls = new ArrayList<>(Utils.getPeerUrls());
+        Collections.shuffle(peerUrls);
+
+        for (String peerUrl : peerUrls) {
+            try {
+                checkPeer(s, peerUrl);
+            } catch (Exception ex) {
+                log.info("Error checking peer {}: {}", peerUrl, ex.getMessage());
+            }
+        }
+    }
+
+    static void checkPeer(ClientSession s, String peerUrl) throws IOException {
+        log.info("Checking peer: {}", peerUrl);
+
+        JsonObject peerInfo = fetchPeerInfo(peerUrl);
+        if (peerInfo == null) return;
+
+        String status = getJsonString(peerInfo, "status");
+        if (!"ready".equals(status) && !"updating".equals(status)) {
+            log.info("Peer {} in non-ready state: {}", peerUrl, status);
+            return;
+        }
+
+        Long peerSetupId = getJsonLong(peerInfo, "setupId");
+        Long peerLoadCounter = getJsonLong(peerInfo, "loadCounter");
+        if (peerSetupId == null || peerLoadCounter == null) {
+            log.info("Peer {} missing setupId or loadCounter", peerUrl);
+            return;
+        }
+
+        syncWithPeer(s, peerUrl, peerSetupId, peerLoadCounter);
+    }
+
+    static void syncWithPeer(ClientSession s, String peerUrl, long peerSetupId, long peerLoadCounter) {
+        Document peerState = getPeerState(s, peerUrl);
+        Long lastSetupId = peerState != null ? peerState.getLong("setupId") : null;
+        Long lastLoadCounter = peerState != null ? peerState.getLong("loadCounter") : null;
+        Boolean fullFetchDone = peerState != null ? peerState.getBoolean("fullFetchDone") : null;
+
+        if (lastSetupId != null && !lastSetupId.equals(peerSetupId)) {
+            log.info("Peer {} was reset (setupId changed), resetting tracking", peerUrl);
+            deletePeerState(s, peerUrl);
+            lastLoadCounter = null;
+            fullFetchDone = null;
+        }
+
+        if (lastLoadCounter != null && lastLoadCounter.equals(peerLoadCounter)) {
+            log.info("Peer {} has no new nanopubs (loadCounter unchanged: {})", peerUrl, peerLoadCounter);
+        } else {
+            long delta = (lastLoadCounter != null) ? peerLoadCounter - lastLoadCounter : Long.MAX_VALUE;
+
+            if (delta > 0 && delta < SMALL_DELTA_THRESHOLD) {
+                log.info("Peer {} has small delta ({}), fetching recent nanopubs", peerUrl, delta);
+                loadRecentNanopubs(s, peerUrl, lastLoadCounter);
+            } else {
+                log.info("Peer {} has large delta, checking per-pubkey lists", peerUrl);
+                // TODO Add per-pubkey/type position tracking for more efficient incremental sync
+                // TODO Add checksum-based binary search to avoid downloading full lists
+                loadByApprovedPubkeys(s, peerUrl);
+            }
+        }
+
+        // TODO Enable one-time full fetch for non-approved pubkey nanopubs:
+        // if (!Boolean.TRUE.equals(fullFetchDone)) {
+        //     loadAllNanopubs(s, peerUrl);
+        // }
+
+        discoverPubkeys(s, peerUrl);
+        updatePeerState(s, peerUrl, peerSetupId, peerLoadCounter);
+    }
+
+    private static void loadAllNanopubs(ClientSession s, String peerUrl) {
+        String requestUrl = peerUrl + "nanopubs.jelly";
+        log.info("Full fetch of all nanopubs from: {}", requestUrl);
+        try {
+            HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(requestUrl));
+            int httpStatus = resp.getStatusLine().getStatusCode();
+            if (httpStatus < 200 || httpStatus >= 300) {
+                EntityUtils.consumeQuietly(resp.getEntity());
+                log.info("Request failed: {} {}", requestUrl, httpStatus);
+                return;
+            }
+            try (InputStream is = resp.getEntity().getContent()) {
+                NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
+                    if (m.isSuccess()) {
+                        NanopubLoader.simpleLoad(s, m.getNanopub());
+                    }
+                });
+            }
+        } catch (IOException ex) {
+            log.info("Failed to fetch all nanopubs from {}: {}", peerUrl, ex.getMessage());
+        }
+    }
+
+    private static void loadRecentNanopubs(ClientSession s, String peerUrl, long afterCounter) {
+        String requestUrl = peerUrl + "nanopubs.jelly?afterCounter=" + afterCounter;
+        log.info("Fetching recent nanopubs from: {}", requestUrl);
+        try {
+            HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(requestUrl));
+            int httpStatus = resp.getStatusLine().getStatusCode();
+            if (httpStatus < 200 || httpStatus >= 300) {
+                EntityUtils.consumeQuietly(resp.getEntity());
+                log.info("Request failed: {} {}", requestUrl, httpStatus);
+                return;
+            }
+            try (InputStream is = resp.getEntity().getContent()) {
+                NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
+                    if (m.isSuccess()) {
+                        NanopubLoader.simpleLoad(s, m.getNanopub());
+                    }
+                });
+            }
+        } catch (IOException ex) {
+            log.info("Failed to fetch recent nanopubs from {}: {}", peerUrl, ex.getMessage());
+        }
+    }
+
+    static void loadByApprovedPubkeys(ClientSession s, String peerUrl) {
+        // Only process approved pubkeys (those with loaded "$" lists)
+        // TODO Add throttled loading for non-approved pubkeys
+        List<String> approvedPubkeys = getApprovedPubkeys(s);
+        log.info("Checking {} approved pubkeys at peer {}", approvedPubkeys.size(), peerUrl);
+
+        for (String pubkeyHash : approvedPubkeys) {
+            String requestUrl = peerUrl + "list/" + pubkeyHash + "/$.jelly";
+            log.info("Fetching list from: {}", requestUrl);
+            try {
+                HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(requestUrl));
+                int httpStatus = resp.getStatusLine().getStatusCode();
+                if (httpStatus < 200 || httpStatus >= 300) {
+                    EntityUtils.consumeQuietly(resp.getEntity());
+                    if (httpStatus != 404) {
+                        log.info("Request failed: {} {}", requestUrl, httpStatus);
+                    }
+                    continue;
+                }
+                try (InputStream is = resp.getEntity().getContent()) {
+                    NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
+                        if (m.isSuccess()) {
+                            NanopubLoader.simpleLoad(s, m.getNanopub());
+                        }
+                    });
+                }
+            } catch (IOException ex) {
+                log.info("Failed to fetch list from {}: {}", requestUrl, ex.getMessage());
+            }
+        }
+    }
+
+    static void discoverPubkeys(ClientSession s, String peerUrl) {
+        log.info("Discovering pubkeys from peer: {}", peerUrl);
+        try {
+            List<String> peerPubkeys = Utils.retrieveListFromJsonUrl(peerUrl + "pubkeys.json");
+            int discovered = 0;
+            for (String pubkeyHash : peerPubkeys) {
+                Document filter = new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH);
+                if (!has(s, "lists", filter)) {
+                    insert(s, "lists", new Document("pubkey", pubkeyHash)
+                            .append("type", NanopubLoader.INTRO_TYPE_HASH)
+                            .append("status", EntryStatus.encountered.getValue()));
+                    discovered++;
+                } else if (!has(s, "lists", new Document(filter).append("status", EntryStatus.loaded.getValue()))) {
+                    // Set status to encountered if not already loaded (fixes null-status entries from older code)
+                    collection("lists").updateMany(s, filter,
+                            new Document("$set", new Document("status", EntryStatus.encountered.getValue())));
+                    discovered++;
+                }
+            }
+            log.info("Discovered {} new pubkeys from peer {}", discovered, peerUrl);
+        } catch (Exception ex) {
+            log.info("Failed to discover pubkeys from {}: {}", peerUrl, ex.getMessage());
+        }
+    }
+
+    static List<String> getApprovedPubkeys(ClientSession s) {
+        List<String> pubkeys = new ArrayList<>();
+        try (MongoCursor<Document> cursor = collection("lists").find(s,
+                new Document("type", "$").append("status", "loaded")).cursor()) {
+            while (cursor.hasNext()) {
+                pubkeys.add(cursor.next().getString("pubkey"));
+            }
+        }
+        return pubkeys;
+    }
+
+    static JsonObject fetchPeerInfo(String peerUrl) {
+        String requestUrl = peerUrl + ".json";
+        try {
+            HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(requestUrl));
+            int httpStatus = resp.getStatusLine().getStatusCode();
+            if (httpStatus < 200 || httpStatus >= 300) {
+                EntityUtils.consumeQuietly(resp.getEntity());
+                log.info("Failed to fetch peer info from {}: {}", peerUrl, httpStatus);
+                return null;
+            }
+            String body = EntityUtils.toString(resp.getEntity());
+            return gson.fromJson(body, JsonObject.class);
+        } catch (IOException ex) {
+            log.info("Failed to connect to peer {}: {}", peerUrl, ex.getMessage());
+            return null;
+        }
+    }
+
+    static Document getPeerState(ClientSession s, String peerUrl) {
+        try (MongoCursor<Document> cursor = collection(Collection.PEER_STATE.toString())
+                .find(s, new Document("_id", peerUrl)).cursor()) {
+            return cursor.hasNext() ? cursor.next() : null;
+        }
+    }
+
+    static void updatePeerState(ClientSession s, String peerUrl, long setupId, long loadCounter) {
+        collection(Collection.PEER_STATE.toString()).updateOne(s,
+                new Document("_id", peerUrl),
+                new Document("$set", new Document("_id", peerUrl)
+                        .append("setupId", setupId)
+                        .append("loadCounter", loadCounter)
+                        .append("fullFetchDone", true)
+                        .append("lastChecked", System.currentTimeMillis())),
+                new com.mongodb.client.model.UpdateOptions().upsert(true));
+    }
+
+    static void deletePeerState(ClientSession s, String peerUrl) {
+        collection(Collection.PEER_STATE.toString()).deleteOne(s, new Document("_id", peerUrl));
+    }
+
+    static String getJsonString(JsonObject obj, String key) {
+        return obj.has(key) && !obj.get(key).isJsonNull() ? obj.get(key).getAsString() : null;
+    }
+
+    static Long getJsonLong(JsonObject obj, String key) {
+        return obj.has(key) && !obj.get(key).isJsonNull() ? obj.get(key).getAsLong() : null;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.registry;
 
+import com.mongodb.ErrorCategory;
 import com.mongodb.MongoWriteException;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCursor;
@@ -206,7 +207,7 @@ public class RegistryPeerConnector {
                                 .append("type", NanopubLoader.INTRO_TYPE_HASH)
                                 .append("status", EntryStatus.encountered.getValue()));
                     } catch (MongoWriteException e) {
-                        if (e.getError().getCode() != 11000) throw e;
+                        if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
                     }
                     discovered++;
                 } else if (!has(s, "lists", new Document(filter).append("status", EntryStatus.loaded.getValue()))) {

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -836,6 +836,13 @@ public enum Task implements Serializable {
             schedule(s, LOAD_FULL.withDelay(100));
         }
 
+        @Override
+        public boolean runAsTransaction() {
+            // Peer sync includes long-running streaming fetches that would exceed
+            // MongoDB's transaction timeout; each operation is individually safe.
+            return false;
+        }
+
     };
 
     private static final Logger log = LoggerFactory.getLogger(Task.class);

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -727,7 +727,7 @@ public enum Task implements Serializable {
                     setServerStatus(s, ready);
                 }
                 log.info("Scheduling optional loading checks");
-                schedule(s, CHECK_MORE_PUBKEYS.withDelay(100));
+                schedule(s, RUN_OPTIONAL_LOAD.withDelay(100));
             } else {
                 final String ph = a.getString("pubkey");
                 if (!ph.equals("$")) {
@@ -843,7 +843,8 @@ public enum Task implements Serializable {
 
     CHECK_NEW {
         public void run(ClientSession s, Document taskDoc) {
-            // TODO Replace this legacy connection with checks at other Nanopub Registries:
+            RegistryPeerConnector.checkPeers(s);
+            // Keep legacy connection during transition period:
             LegacyConnector.checkForNewNanopubs(s);
             // TODO Somehow throttle the loading of such potentially non-approved nanopubs
 

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -731,7 +731,7 @@ public enum Task implements Serializable {
                     setServerStatus(s, ready);
                 }
                 log.info("Scheduling optional loading checks");
-                schedule(s, CHECK_MORE_PUBKEYS.withDelay(100));
+                schedule(s, RUN_OPTIONAL_LOAD.withDelay(100));
             } else {
                 final String ph = a.getString("pubkey");
                 if (!ph.equals("$")) {
@@ -847,7 +847,8 @@ public enum Task implements Serializable {
 
     CHECK_NEW {
         public void run(ClientSession s, Document taskDoc) {
-            // TODO Replace this legacy connection with checks at other Nanopub Registries:
+            RegistryPeerConnector.checkPeers(s);
+            // Keep legacy connection during transition period:
             LegacyConnector.checkForNewNanopubs(s);
             // TODO Somehow throttle the loading of such potentially non-approved nanopubs
 

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -766,25 +766,6 @@ public enum Task implements Serializable {
 
     },
 
-    CHECK_MORE_PUBKEYS {
-        public void run(ClientSession s, Document taskDoc) {
-            try {
-                for (String pubkeyHash : Utils.retrieveListFromJsonUrl(Utils.getRandomPeer() + "pubkeys.json")) {
-                    Validate.notNull(pubkeyHash);
-                    Document d = new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH);
-                    if (!has(s, "lists", d)) {
-                        insert(s, "lists", d.append("status", encountered.getValue()));
-                    }
-                }
-            } catch (Exception ex) {
-                throw new RuntimeException(ex);
-            }
-
-            schedule(s, RUN_OPTIONAL_LOAD.withDelay(100));
-        }
-
-    },
-
     RUN_OPTIONAL_LOAD {
         public void run(ClientSession s, Document taskDoc) {
             Document di = getOne(s, "lists", new Document("type", INTRO_TYPE_HASH).append("status", encountered.getValue()));
@@ -820,7 +801,7 @@ public enum Task implements Serializable {
                 Document df = new Document("pubkey", pubkeyHash).append("type", "$");
                 if (!has(s, "lists", df)) insert(s, "lists", df.append("status", encountered.getValue()));
 
-                schedule(s, CHECK_NEW.withDelay(100));
+                schedule(s, CHECK_NEW.withDelay(500));
                 return;
             }
 
@@ -840,7 +821,7 @@ public enum Task implements Serializable {
                 set(s, "lists", df.append("status", loaded.getValue()));
             }
 
-            schedule(s, CHECK_NEW.withDelay(100));
+            schedule(s, CHECK_NEW.withDelay(500));
         }
 
     },

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -717,7 +717,7 @@ public enum Task implements Serializable {
             if ("false".equals(System.getenv("REGISTRY_PERFORM_FULL_LOAD"))) return;
 
             ServerStatus status = getServerStatus(s);
-            if (status != coreReady && status != ready) {
+            if (status != coreReady && status != ready && status != updating) {
                 log.info("Server currently not ready; checking again later");
                 schedule(s, LOAD_FULL.withDelay(60 * 1000));
                 return;

--- a/src/main/java/com/knowledgepixels/registry/Utils.java
+++ b/src/main/java/com/knowledgepixels/registry/Utils.java
@@ -48,8 +48,10 @@ public class Utils {
     public static String getMimeType(RoutingContext context, String supported) {
         List<String> supportedList = Arrays.asList(StringUtils.split(supported, ','));
         String mimeType = supportedList.getFirst();
+        String acceptHeader = context.request().getHeader("Accept");
+        if (acceptHeader == null) return mimeType;
         try {
-            mimeType = MIMEParse.bestMatch(supportedList, context.request().getHeader("Accept"));
+            mimeType = MIMEParse.bestMatch(supportedList, acceptHeader);
         } catch (Exception ex) {
             logger.error("Error parsing Accept header.", ex);
         }

--- a/src/main/java/com/knowledgepixels/registry/db/IndexInitializer.java
+++ b/src/main/java/com/knowledgepixels/registry/db/IndexInitializer.java
@@ -56,6 +56,8 @@ public final class IndexInitializer {
 
         collection("hashes").createIndex(mongoSession, ascending("hash"), unique);
         collection("hashes").createIndex(mongoSession, ascending("value"), unique);
+
+        collection(Collection.PEER_STATE.toString()).createIndex(mongoSession, ascending("setupId"));
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorIT.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorIT.java
@@ -1,0 +1,41 @@
+package com.knowledgepixels.registry;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static com.knowledgepixels.registry.RegistryPeerConnector.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests that connect to live peer registries.
+ */
+class RegistryPeerConnectorIT {
+
+    @Test
+    void fetchPeerInfo_petapico() {
+        JsonObject info = fetchPeerInfo("https://registry.petapico.org/");
+        assertNotNull(info, "Should get response from petapico registry");
+        assertNotNull(getJsonLong(info, "setupId"), "Should have setupId");
+        assertNotNull(getJsonLong(info, "loadCounter"), "Should have loadCounter");
+        assertNotNull(getJsonString(info, "status"), "Should have status");
+        assertEquals("ready", getJsonString(info, "status"));
+        assertTrue(getJsonLong(info, "loadCounter") > 0, "loadCounter should be positive");
+    }
+
+    @Test
+    void fetchPeerInfo_knowledgepixels() {
+        JsonObject info = fetchPeerInfo("https://registry.knowledgepixels.com/");
+        assertNotNull(info, "Should get response from knowledgepixels registry");
+        assertNotNull(getJsonLong(info, "setupId"), "Should have setupId");
+        assertNotNull(getJsonLong(info, "loadCounter"), "Should have loadCounter");
+        assertNotNull(getJsonString(info, "status"), "Should have status");
+        assertEquals("ready", getJsonString(info, "status"));
+        assertTrue(getJsonLong(info, "loadCounter") > 0, "loadCounter should be positive");
+    }
+
+    @Test
+    void fetchPeerInfo_invalidUrl_returnsNull() {
+        JsonObject info = fetchPeerInfo("https://nonexistent.invalid.example.com/");
+        assertNull(info, "Should return null for unreachable peer");
+    }
+}

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorIT.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorIT.java
@@ -1,7 +1,9 @@
 package com.knowledgepixels.registry;
 
-import com.google.gson.JsonObject;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpHead;
 import org.junit.jupiter.api.Test;
+import org.nanopub.NanopubUtils;
 
 import static com.knowledgepixels.registry.RegistryPeerConnector.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,31 +13,30 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class RegistryPeerConnectorIT {
 
-    @Test
-    void fetchPeerInfo_petapico() {
-        JsonObject info = fetchPeerInfo("https://registry.petapico.org/");
-        assertNotNull(info, "Should get response from petapico registry");
-        assertNotNull(getJsonLong(info, "setupId"), "Should have setupId");
-        assertNotNull(getJsonLong(info, "loadCounter"), "Should have loadCounter");
-        assertNotNull(getJsonString(info, "status"), "Should have status");
-        assertEquals("ready", getJsonString(info, "status"));
-        assertTrue(getJsonLong(info, "loadCounter") > 0, "loadCounter should be positive");
+    private HttpResponse headRequest(String url) throws Exception {
+        return NanopubUtils.getHttpClient().execute(new HttpHead(url));
     }
 
     @Test
-    void fetchPeerInfo_knowledgepixels() {
-        JsonObject info = fetchPeerInfo("https://registry.knowledgepixels.com/");
-        assertNotNull(info, "Should get response from knowledgepixels registry");
-        assertNotNull(getJsonLong(info, "setupId"), "Should have setupId");
-        assertNotNull(getJsonLong(info, "loadCounter"), "Should have loadCounter");
-        assertNotNull(getJsonString(info, "status"), "Should have status");
-        assertEquals("ready", getJsonString(info, "status"));
-        assertTrue(getJsonLong(info, "loadCounter") > 0, "loadCounter should be positive");
+    void headRequest_petapico() throws Exception {
+        HttpResponse resp = headRequest("https://registry.petapico.org/");
+        assertNotNull(getHeaderLong(resp, "Nanopub-Registry-Setup-Id"), "Should have setupId");
+        assertNotNull(getHeaderLong(resp, "Nanopub-Registry-Load-Counter"), "Should have loadCounter");
+        assertEquals("ready", getHeader(resp, "Nanopub-Registry-Status"));
+        assertTrue(getHeaderLong(resp, "Nanopub-Registry-Load-Counter") > 0, "loadCounter should be positive");
     }
 
     @Test
-    void fetchPeerInfo_invalidUrl_returnsNull() {
-        JsonObject info = fetchPeerInfo("https://nonexistent.invalid.example.com/");
-        assertNull(info, "Should return null for unreachable peer");
+    void headRequest_knowledgepixels() throws Exception {
+        HttpResponse resp = headRequest("https://registry.knowledgepixels.com/");
+        assertNotNull(getHeaderLong(resp, "Nanopub-Registry-Setup-Id"), "Should have setupId");
+        assertNotNull(getHeaderLong(resp, "Nanopub-Registry-Load-Counter"), "Should have loadCounter");
+        assertEquals("ready", getHeader(resp, "Nanopub-Registry-Status"));
+        assertTrue(getHeaderLong(resp, "Nanopub-Registry-Load-Counter") > 0, "loadCounter should be positive");
+    }
+
+    @Test
+    void headRequest_invalidUrl_throws() {
+        assertThrows(Exception.class, () -> headRequest("https://nonexistent.invalid.example.com/"));
     }
 }

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
@@ -16,8 +16,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.mongodb.MongoDBContainer;
 
-import java.util.List;
-
 import static com.knowledgepixels.registry.RegistryDB.collection;
 import static com.knowledgepixels.registry.RegistryPeerConnector.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -194,41 +192,6 @@ class RegistryPeerConnectorTest {
         }
 
         @Test
-        void getApprovedPubkeys_returnsEmptyWhenNoLists() {
-            List<String> pubkeys = getApprovedPubkeys(session);
-            assertTrue(pubkeys.isEmpty());
-        }
-
-        @Test
-        void getApprovedPubkeys_returnsLoadedPubkeys() {
-            collection("lists").insertOne(session,
-                    new Document("pubkey", "abc123").append("type", "$").append("status", "loaded"));
-            collection("lists").insertOne(session,
-                    new Document("pubkey", "def456").append("type", "$").append("status", "loaded"));
-            // This one should NOT be returned (status is not "loaded")
-            collection("lists").insertOne(session,
-                    new Document("pubkey", "ghi789").append("type", "$").append("status", "encountered"));
-
-            List<String> pubkeys = getApprovedPubkeys(session);
-            assertEquals(2, pubkeys.size());
-            assertTrue(pubkeys.contains("abc123"));
-            assertTrue(pubkeys.contains("def456"));
-            assertFalse(pubkeys.contains("ghi789"));
-        }
-
-        @Test
-        void getApprovedPubkeys_excludesNonDollarTypes() {
-            collection("lists").insertOne(session,
-                    new Document("pubkey", "abc123").append("type", "$").append("status", "loaded"));
-            collection("lists").insertOne(session,
-                    new Document("pubkey", "abc123").append("type", "introHash").append("status", "loaded"));
-
-            List<String> pubkeys = getApprovedPubkeys(session);
-            assertEquals(1, pubkeys.size());
-            assertEquals("abc123", pubkeys.getFirst());
-        }
-
-        @Test
         void discoverPubkeys_createsEncounteredIntroLists() {
             // Simulate what discoverPubkeys does: insert encountered intro lists for unknown pubkeys
             String pubkeyHash = "newPubkey123";
@@ -300,15 +263,6 @@ class RegistryPeerConnectorTest {
             assertEquals(200L, state2.getLong("setupId"));
             assertEquals(500L, state1.getLong("loadCounter"));
             assertEquals(600L, state2.getLong("loadCounter"));
-        }
-    }
-
-    @Nested
-    class SmallDeltaThresholdTests {
-
-        @Test
-        void thresholdIsReasonable() {
-            assertEquals(100, SMALL_DELTA_THRESHOLD);
         }
     }
 

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
@@ -1,0 +1,267 @@
+package com.knowledgepixels.registry;
+
+import com.google.gson.JsonObject;
+import com.knowledgepixels.registry.utils.FakeEnv;
+import com.knowledgepixels.registry.utils.TestUtils;
+import com.mongodb.client.ClientSession;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import java.util.List;
+
+import static com.knowledgepixels.registry.RegistryDB.collection;
+import static com.knowledgepixels.registry.RegistryPeerConnector.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RegistryPeerConnectorTest {
+
+    @Nested
+    class JsonHelperTests {
+
+        @Test
+        void getJsonString_returnsValue() {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("status", "ready");
+            assertEquals("ready", getJsonString(obj, "status"));
+        }
+
+        @Test
+        void getJsonString_returnsNullForMissingKey() {
+            JsonObject obj = new JsonObject();
+            assertNull(getJsonString(obj, "missing"));
+        }
+
+        @Test
+        void getJsonString_returnsNullForJsonNull() {
+            JsonObject obj = new JsonObject();
+            obj.add("status", com.google.gson.JsonNull.INSTANCE);
+            assertNull(getJsonString(obj, "status"));
+        }
+
+        @Test
+        void getJsonLong_returnsValue() {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("loadCounter", 42000L);
+            assertEquals(42000L, getJsonLong(obj, "loadCounter"));
+        }
+
+        @Test
+        void getJsonLong_returnsNullForMissingKey() {
+            JsonObject obj = new JsonObject();
+            assertNull(getJsonLong(obj, "missing"));
+        }
+
+        @Test
+        void getJsonLong_returnsNullForJsonNull() {
+            JsonObject obj = new JsonObject();
+            obj.add("loadCounter", com.google.gson.JsonNull.INSTANCE);
+            assertNull(getJsonLong(obj, "loadCounter"));
+        }
+    }
+
+    @Nested
+    @Testcontainers
+    class PeerStateTests {
+
+        private FakeEnv fakeEnv;
+        private ClientSession session;
+
+        @Container
+        private final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:7.0.0");
+
+        @BeforeEach
+        void setUp() throws Exception {
+            fakeEnv = TestUtils.setupFakeEnv();
+            TestUtils.setupDBEnv(mongoDBContainer, "nanopubRegistryTest");
+            TestUtils.clearStaticFields(RegistryDB.class, "mongoClient", "mongoDB");
+            RegistryDB.init();
+            session = RegistryDB.getClient().startSession();
+        }
+
+        @AfterEach
+        void tearDown() throws Exception {
+            if (session != null) session.close();
+            TestUtils.cleanupDataDir();
+            fakeEnv.reset();
+        }
+
+        @Test
+        void getPeerState_returnsNullForUnknownPeer() {
+            assertNull(getPeerState(session, "https://unknown.example.com/"));
+        }
+
+        @Test
+        void updatePeerState_createsPeerState() {
+            updatePeerState(session, "https://peer.example.com/", 123L, 42000L);
+
+            Document state = getPeerState(session, "https://peer.example.com/");
+            assertNotNull(state);
+            assertEquals(123L, state.getLong("setupId"));
+            assertEquals(42000L, state.getLong("loadCounter"));
+            assertNotNull(state.getLong("lastChecked"));
+        }
+
+        @Test
+        void updatePeerState_updatesExistingState() {
+            updatePeerState(session, "https://peer.example.com/", 123L, 100L);
+            updatePeerState(session, "https://peer.example.com/", 123L, 200L);
+
+            Document state = getPeerState(session, "https://peer.example.com/");
+            assertEquals(200L, state.getLong("loadCounter"));
+            assertEquals(1, collection(Collection.PEER_STATE.toString()).countDocuments(session));
+        }
+
+        @Test
+        void deletePeerState_removesState() {
+            updatePeerState(session, "https://peer.example.com/", 123L, 42000L);
+            assertNotNull(getPeerState(session, "https://peer.example.com/"));
+
+            deletePeerState(session, "https://peer.example.com/");
+            assertNull(getPeerState(session, "https://peer.example.com/"));
+        }
+
+        @Test
+        void syncWithPeer_skipsWhenLoadCounterUnchanged() {
+            updatePeerState(session, "https://peer.example.com/", 123L, 500L);
+
+            syncWithPeer(session, "https://peer.example.com/", 123L, 500L);
+
+            Document state = getPeerState(session, "https://peer.example.com/");
+            assertEquals(500L, state.getLong("loadCounter"));
+        }
+
+        @Test
+        void syncWithPeer_resetsOnSetupIdChange() {
+            updatePeerState(session, "https://peer.example.com/", 100L, 500L);
+
+            // Sync with a different setupId — should reset and treat as new peer
+            // This will try to load by pubkeys (which will find none), then update state
+            syncWithPeer(session, "https://peer.example.com/", 200L, 600L);
+
+            Document state = getPeerState(session, "https://peer.example.com/");
+            assertEquals(200L, state.getLong("setupId"));
+            assertEquals(600L, state.getLong("loadCounter"));
+        }
+
+        @Test
+        void syncWithPeer_updatesStateAfterSync() {
+            // First time seeing this peer (no prior state)
+            syncWithPeer(session, "https://peer.example.com/", 123L, 42000L);
+
+            Document state = getPeerState(session, "https://peer.example.com/");
+            assertNotNull(state);
+            assertEquals(123L, state.getLong("setupId"));
+            assertEquals(42000L, state.getLong("loadCounter"));
+        }
+
+        @Test
+        void getApprovedPubkeys_returnsEmptyWhenNoLists() {
+            List<String> pubkeys = getApprovedPubkeys(session);
+            assertTrue(pubkeys.isEmpty());
+        }
+
+        @Test
+        void getApprovedPubkeys_returnsLoadedPubkeys() {
+            collection("lists").insertOne(session,
+                    new Document("pubkey", "abc123").append("type", "$").append("status", "loaded"));
+            collection("lists").insertOne(session,
+                    new Document("pubkey", "def456").append("type", "$").append("status", "loaded"));
+            // This one should NOT be returned (status is not "loaded")
+            collection("lists").insertOne(session,
+                    new Document("pubkey", "ghi789").append("type", "$").append("status", "encountered"));
+
+            List<String> pubkeys = getApprovedPubkeys(session);
+            assertEquals(2, pubkeys.size());
+            assertTrue(pubkeys.contains("abc123"));
+            assertTrue(pubkeys.contains("def456"));
+            assertFalse(pubkeys.contains("ghi789"));
+        }
+
+        @Test
+        void getApprovedPubkeys_excludesNonDollarTypes() {
+            collection("lists").insertOne(session,
+                    new Document("pubkey", "abc123").append("type", "$").append("status", "loaded"));
+            collection("lists").insertOne(session,
+                    new Document("pubkey", "abc123").append("type", "introHash").append("status", "loaded"));
+
+            List<String> pubkeys = getApprovedPubkeys(session);
+            assertEquals(1, pubkeys.size());
+            assertEquals("abc123", pubkeys.getFirst());
+        }
+
+        @Test
+        void discoverPubkeys_createsEncounteredIntroLists() {
+            // Simulate what discoverPubkeys does: insert encountered intro lists for unknown pubkeys
+            String pubkeyHash = "newPubkey123";
+            Document d = new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH);
+            assertFalse(RegistryDB.has(session, "lists", d));
+
+            RegistryDB.insert(session, "lists", d.append("status", EntryStatus.encountered.getValue()));
+            assertTrue(RegistryDB.has(session, "lists",
+                    new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH)));
+
+            // Verify the status is "encountered"
+            try (com.mongodb.client.MongoCursor<Document> cursor = collection("lists").find(session,
+                    new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH)).cursor()) {
+                assertTrue(cursor.hasNext());
+                assertEquals(EntryStatus.encountered.getValue(), cursor.next().getString("status"));
+            }
+        }
+
+        @Test
+        void discoverPubkeys_skipsAlreadyKnownPubkeys() {
+            // Pre-insert a loaded list for this pubkey
+            String pubkeyHash = "existingPubkey";
+            collection("lists").insertOne(session,
+                    new Document("pubkey", pubkeyHash)
+                            .append("type", NanopubLoader.INTRO_TYPE_HASH)
+                            .append("status", "loaded"));
+
+            // Verify has() returns true — discoverPubkeys would skip this pubkey
+            assertTrue(RegistryDB.has(session, "lists",
+                    new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH)));
+
+            // Should still be exactly 1 document
+            assertEquals(1, collection("lists").countDocuments(session,
+                    new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH)));
+        }
+
+        @Test
+        void multiplePeers_trackedIndependently() {
+            updatePeerState(session, "https://peer1.example.com/", 100L, 500L);
+            updatePeerState(session, "https://peer2.example.com/", 200L, 600L);
+
+            Document state1 = getPeerState(session, "https://peer1.example.com/");
+            Document state2 = getPeerState(session, "https://peer2.example.com/");
+
+            assertEquals(100L, state1.getLong("setupId"));
+            assertEquals(200L, state2.getLong("setupId"));
+            assertEquals(500L, state1.getLong("loadCounter"));
+            assertEquals(600L, state2.getLong("loadCounter"));
+        }
+    }
+
+    @Nested
+    class SmallDeltaThresholdTests {
+
+        @Test
+        void thresholdIsReasonable() {
+            assertEquals(100, SMALL_DELTA_THRESHOLD);
+        }
+    }
+
+    @Nested
+    class CollectionEnumTests {
+
+        @Test
+        void peerStateCollectionName() {
+            assertEquals("peerState", Collection.PEER_STATE.toString());
+        }
+    }
+}

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
@@ -1,9 +1,12 @@
 package com.knowledgepixels.registry;
 
-import com.google.gson.JsonObject;
 import com.knowledgepixels.registry.utils.FakeEnv;
 import com.knowledgepixels.registry.utils.TestUtils;
 import com.mongodb.client.ClientSession;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,46 +25,50 @@ import static org.junit.jupiter.api.Assertions.*;
 class RegistryPeerConnectorTest {
 
     @Nested
-    class JsonHelperTests {
+    class HeaderHelperTests {
 
-        @Test
-        void getJsonString_returnsValue() {
-            JsonObject obj = new JsonObject();
-            obj.addProperty("status", "ready");
-            assertEquals("ready", getJsonString(obj, "status"));
+        private HttpResponse makeResponse(String... headers) {
+            HttpResponse resp = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200, "OK"));
+            for (int i = 0; i < headers.length; i += 2) {
+                resp.setHeader(headers[i], headers[i + 1]);
+            }
+            return resp;
         }
 
         @Test
-        void getJsonString_returnsNullForMissingKey() {
-            JsonObject obj = new JsonObject();
-            assertNull(getJsonString(obj, "missing"));
+        void getHeader_returnsValue() {
+            HttpResponse resp = makeResponse("Nanopub-Registry-Status", "ready");
+            assertEquals("ready", getHeader(resp, "Nanopub-Registry-Status"));
         }
 
         @Test
-        void getJsonString_returnsNullForJsonNull() {
-            JsonObject obj = new JsonObject();
-            obj.add("status", com.google.gson.JsonNull.INSTANCE);
-            assertNull(getJsonString(obj, "status"));
+        void getHeader_returnsNullForMissingHeader() {
+            HttpResponse resp = makeResponse();
+            assertNull(getHeader(resp, "Nanopub-Registry-Status"));
         }
 
         @Test
-        void getJsonLong_returnsValue() {
-            JsonObject obj = new JsonObject();
-            obj.addProperty("loadCounter", 42000L);
-            assertEquals(42000L, getJsonLong(obj, "loadCounter"));
+        void getHeaderLong_returnsValue() {
+            HttpResponse resp = makeResponse("Nanopub-Registry-Load-Counter", "42000");
+            assertEquals(42000L, getHeaderLong(resp, "Nanopub-Registry-Load-Counter"));
         }
 
         @Test
-        void getJsonLong_returnsNullForMissingKey() {
-            JsonObject obj = new JsonObject();
-            assertNull(getJsonLong(obj, "missing"));
+        void getHeaderLong_returnsNullForMissingHeader() {
+            HttpResponse resp = makeResponse();
+            assertNull(getHeaderLong(resp, "Nanopub-Registry-Load-Counter"));
         }
 
         @Test
-        void getJsonLong_returnsNullForJsonNull() {
-            JsonObject obj = new JsonObject();
-            obj.add("loadCounter", com.google.gson.JsonNull.INSTANCE);
-            assertNull(getJsonLong(obj, "loadCounter"));
+        void getHeaderLong_returnsNullForNullValue() {
+            HttpResponse resp = makeResponse("Nanopub-Registry-Load-Counter", "null");
+            assertNull(getHeaderLong(resp, "Nanopub-Registry-Load-Counter"));
+        }
+
+        @Test
+        void getHeaderLong_returnsNullForInvalidNumber() {
+            HttpResponse resp = makeResponse("Nanopub-Registry-Load-Counter", "notanumber");
+            assertNull(getHeaderLong(resp, "Nanopub-Registry-Load-Counter"));
         }
     }
 

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
@@ -105,19 +105,29 @@ class RegistryPeerConnectorTest {
 
         @Test
         void updatePeerState_createsPeerState() {
-            updatePeerState(session, "https://peer.example.com/", 123L, 42000L);
+            updatePeerState(session, "https://peer.example.com/", 123L, 42000L, true);
 
             Document state = getPeerState(session, "https://peer.example.com/");
             assertNotNull(state);
             assertEquals(123L, state.getLong("setupId"));
             assertEquals(42000L, state.getLong("loadCounter"));
+            assertTrue(state.getBoolean("fullFetchDone"));
             assertNotNull(state.getLong("lastChecked"));
         }
 
         @Test
+        void updatePeerState_storesFullFetchDoneFalse() {
+            updatePeerState(session, "https://peer.example.com/", 123L, 42000L, false);
+
+            Document state = getPeerState(session, "https://peer.example.com/");
+            assertNotNull(state);
+            assertFalse(state.getBoolean("fullFetchDone"));
+        }
+
+        @Test
         void updatePeerState_updatesExistingState() {
-            updatePeerState(session, "https://peer.example.com/", 123L, 100L);
-            updatePeerState(session, "https://peer.example.com/", 123L, 200L);
+            updatePeerState(session, "https://peer.example.com/", 123L, 100L, true);
+            updatePeerState(session, "https://peer.example.com/", 123L, 200L, true);
 
             Document state = getPeerState(session, "https://peer.example.com/");
             assertEquals(200L, state.getLong("loadCounter"));
@@ -126,7 +136,7 @@ class RegistryPeerConnectorTest {
 
         @Test
         void deletePeerState_removesState() {
-            updatePeerState(session, "https://peer.example.com/", 123L, 42000L);
+            updatePeerState(session, "https://peer.example.com/", 123L, 42000L, true);
             assertNotNull(getPeerState(session, "https://peer.example.com/"));
 
             deletePeerState(session, "https://peer.example.com/");
@@ -135,7 +145,7 @@ class RegistryPeerConnectorTest {
 
         @Test
         void syncWithPeer_skipsWhenLoadCounterUnchanged() {
-            updatePeerState(session, "https://peer.example.com/", 123L, 500L);
+            updatePeerState(session, "https://peer.example.com/", 123L, 500L, true);
 
             syncWithPeer(session, "https://peer.example.com/", 123L, 500L);
 
@@ -145,7 +155,7 @@ class RegistryPeerConnectorTest {
 
         @Test
         void syncWithPeer_resetsOnSetupIdChange() {
-            updatePeerState(session, "https://peer.example.com/", 100L, 500L);
+            updatePeerState(session, "https://peer.example.com/", 100L, 500L, true);
 
             // Sync with a different setupId — should reset and treat as new peer
             // This will try to load by pubkeys (which will find none), then update state
@@ -159,12 +169,28 @@ class RegistryPeerConnectorTest {
         @Test
         void syncWithPeer_updatesStateAfterSync() {
             // First time seeing this peer (no prior state)
+            // Full fetch will fail (no real HTTP endpoint), so fullFetchDone should be false
             syncWithPeer(session, "https://peer.example.com/", 123L, 42000L);
 
             Document state = getPeerState(session, "https://peer.example.com/");
             assertNotNull(state);
             assertEquals(123L, state.getLong("setupId"));
             assertEquals(42000L, state.getLong("loadCounter"));
+            assertFalse(state.getBoolean("fullFetchDone"),
+                    "fullFetchDone should be false when full fetch fails");
+        }
+
+        @Test
+        void syncWithPeer_preservesFullFetchDoneTrue() {
+            // Simulate a prior successful full fetch
+            updatePeerState(session, "https://peer.example.com/", 123L, 500L, true);
+
+            // Sync again with new loadCounter — fullFetchDone should remain true
+            syncWithPeer(session, "https://peer.example.com/", 123L, 600L);
+
+            Document state = getPeerState(session, "https://peer.example.com/");
+            assertTrue(state.getBoolean("fullFetchDone"),
+                    "fullFetchDone should remain true after subsequent syncs");
         }
 
         @Test
@@ -241,8 +267,8 @@ class RegistryPeerConnectorTest {
 
         @Test
         void multiplePeers_trackedIndependently() {
-            updatePeerState(session, "https://peer1.example.com/", 100L, 500L);
-            updatePeerState(session, "https://peer2.example.com/", 200L, 600L);
+            updatePeerState(session, "https://peer1.example.com/", 100L, 500L, true);
+            updatePeerState(session, "https://peer2.example.com/", 200L, 600L, true);
 
             Document state1 = getPeerState(session, "https://peer1.example.com/");
             Document state2 = getPeerState(session, "https://peer2.example.com/");

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
@@ -248,6 +248,29 @@ class RegistryPeerConnectorTest {
         }
 
         @Test
+        void discoverPubkeys_duplicateInsertDoesNotThrow() {
+            // Simulate a concurrent insert: pre-insert an encountered entry, then try inserting again
+            String pubkeyHash = "racePubkey";
+            Document doc = new Document("pubkey", pubkeyHash)
+                    .append("type", NanopubLoader.INTRO_TYPE_HASH)
+                    .append("status", EntryStatus.encountered.getValue());
+            RegistryDB.insert(session, "lists", doc);
+
+            // A second insert with the same key should be silently ignored (duplicate key)
+            try {
+                RegistryDB.insert(session, "lists", new Document("pubkey", pubkeyHash)
+                        .append("type", NanopubLoader.INTRO_TYPE_HASH)
+                        .append("status", EntryStatus.encountered.getValue()));
+            } catch (com.mongodb.MongoWriteException e) {
+                assertEquals(11000, e.getError().getCode(), "Should be a duplicate key error");
+            }
+
+            // Should still be exactly 1 document
+            assertEquals(1, collection("lists").countDocuments(session,
+                    new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH)));
+        }
+
+        @Test
         void discoverPubkeys_skipsAlreadyKnownPubkeys() {
             // Pre-insert a loaded list for this pubkey
             String pubkeyHash = "existingPubkey";


### PR DESCRIPTION
Closes #74

## Summary
- Add `RegistryPeerConnector` for peer-to-peer registry synchronization, replacing legacy nanopub-server polling in `CHECK_NEW`
- Track per-peer state (`setupId`, `loadCounter`) in new `peerState` collection for efficient incremental sync
- Small delta (<100 new nanopubs): fetch via `/nanopubs.jelly?afterCounter=X`
- Large delta (or first sync): iterate approved pubkey `$.jelly` lists
- Discover new pubkeys from peers' `/pubkeys.json` and create `encountered` intro lists for `RUN_OPTIONAL_LOAD`
- Create `encountered` intro lists in `simpleLoad` for nanopubs from unknown pubkeys
- Update `design.md` with peer sync documentation and task workflow changes
- Add unit tests (Testcontainers) and integration tests against live registries

## Not yet implemented
- One-time full fetch of all nanopubs (code exists but commented out, pending investigation of non-approved pubkey loading)
- Per-pubkey/type position tracking for incremental sync
- Checksum-based binary search to avoid downloading full lists
- Throttled loading for non-approved pubkeys during peer sync

## Test plan
- [x] Unit tests for peer state CRUD, JSON helpers, pubkey discovery logic
- [x] Integration tests against live registries (petapico, knowledgepixels)
- [x] Manual testing with local registry instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)