### PR TITLE
fix: skip seen accounts without trust paths instead of aborting depth

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -386,8 +386,12 @@ public enum Task implements Serializable {
                 trustPath = null;
             }
 
-            if (trustPath == null) {
+            if (agentAccount == null) {
                 schedule(s, FINISH_ITERATION.with("depth", depth).append("load-count", loadCount));
+            } else if (trustPath == null) {
+                // Account was seen but has no trust path at this depth; skip it
+                set(s, "accounts_loading", agentAccount.append("status", skipped.getValue()));
+                schedule(s, LOAD_CORE.with("depth", depth).append("load-count", loadCount));
             } else if (trustPath.getDouble("ratio") < MIN_TRUST_PATH_RATIO) {
                 set(s, "accounts_loading", agentAccount.append("status", skipped.getValue()));
                 Document d = new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH);


### PR DESCRIPTION
Closes #76

## Summary
- `LOAD_CORE` picks `seen` accounts one at a time and looks up their trust path at the current depth
- When an account had no trust path, the code treated it the same as "no more seen accounts" and jumped to `FINISH_ITERATION`, abandoning all remaining `seen` accounts at that depth
- In practice, 2 accounts without trust paths at depth 2 caused 245 other accounts (that did have trust paths) to be skipped entirely, leaving them permanently as "seen"
- Fix: when a `seen` account has no trust path, mark it as `skipped` and continue processing the next `seen` account

## Test plan
- [x] Verified 245 of 247 depth-2 `seen` accounts have valid trust paths in the DB
- [x] Manual testing with local registry instance
- [ ] After deploying, verify `seen` account count drops and agent count increases

🤖 Generated with [Claude Code](https://claude.com/claude-code)