### PR TITLE
feat: reject nanopubs with graph URIs not matching base URI

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -364,6 +364,13 @@ public class RegistryDB {
             logger.info("Nanopub has a future timestamp: {}", nanopub.getUri());
             return false;
         }
+        String nanopubUriStr = nanopub.getUri().stringValue();
+        for (IRI graphUri : nanopub.getGraphUris()) {
+            if (!graphUri.stringValue().startsWith(nanopubUriStr)) {
+                logger.info("Nanopub has graph URI not matching base URI: {}", nanopub.getUri());
+                return false;
+            }
+        }
         String pubkey = getPubkey(nanopub);
         if (pubkey == null) {
             logger.info("Ignoring invalid nanopub: {}", nanopub.getUri());

--- a/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
@@ -23,6 +23,7 @@ import org.testcontainers.mongodb.MongoDBContainer;
 import java.io.File;
 import java.io.IOException;
 import java.util.Calendar;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -354,8 +355,26 @@ class RegistryDBTest {
         IRI uri = SimpleValueFactory.getInstance().createIRI("http://example.org/test");
         when(nanopub.getUri()).thenReturn(uri);
         when(nanopub.getCreationTime()).thenReturn(null);
+        when(nanopub.getGraphUris()).thenReturn(Set.of());
 
         // Will pass the timestamp check but fail on signature validation (no pubkey)
+        assertFalse(RegistryDB.loadNanopub(session, nanopub));
+    }
+
+    @Test
+    void loadNanopubRejectsMismatchedGraphUris() {
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        Nanopub nanopub = mock(Nanopub.class);
+        when(nanopub.getTripleCount()).thenReturn(10);
+        when(nanopub.getByteCount()).thenReturn(100L);
+        when(nanopub.getCreationTime()).thenReturn(null);
+        IRI nanopubUri = SimpleValueFactory.getInstance().createIRI("https://w3id.org/np/RA3QeEArKrJhMi5hGQJwjizvDEPKnaM2wME9iuKItk_nE");
+        IRI mismatchedGraphUri = SimpleValueFactory.getInstance().createIRI("https://w3id.org/np/RA54f2f2ef2408bf88c12fbb8fd62844263ab83ef5c22/Head");
+        when(nanopub.getUri()).thenReturn(nanopubUri);
+        when(nanopub.getGraphUris()).thenReturn(Set.of(mismatchedGraphUri));
+
         assertFalse(RegistryDB.loadNanopub(session, nanopub));
     }
 


### PR DESCRIPTION
## Summary
- Reject nanopubs whose graph URIs don't start with the nanopub's base URI, preventing graph overlap in the triple store
- Validation added in `RegistryDB.loadNanopub()` so it covers all entry points (POST, peer loading, task processing)
- Added test for mismatched graph URI rejection; fixed existing mock test to stub `getGraphUris()`

Closes #71

## Test plan
- [x] `loadNanopubRejectsMismatchedGraphUris` test verifies nanopubs with mismatched graph URIs are rejected
- [x] Existing `loadNanopubAcceptsNullCreationTime` test updated and passing
- [x] `loadNanopubAcceptsPastTimestamp` test (uses real signed nanopub with matching graph URIs) still passes
- [x] Full `RegistryDBTest` suite passes (31 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)