### PR TITLE
Add REGISTRY_PRIORITIZE_ALL_PUBKEYS and remove full fetch

### DIFF
--- a/design.md
+++ b/design.md
@@ -125,11 +125,9 @@ The `CHECK_NEW` task invokes `RegistryPeerConnector.checkPeers()`, which iterate
 2. Skip peers with non-ready status (only `ready` and `updating` are accepted).
 3. If `setupId` changed since last check, delete stored peer state and treat as new.
 4. If `loadCounter` is unchanged, skip (nothing new).
-5. **Small delta** (loadCounter difference < 100): fetch recent nanopubs via `/nanopubs.jelly?afterCounter=X`.
-6. **Large delta** (or first sync): iterate over approved pubkeys and download their `$.jelly` lists from the peer. Only pubkeys with loaded `$` lists are processed.
-7. **Full fetch** (once per peer): if `fullFetchDone` is not set, fetch all nanopubs via `/nanopubs.jelly` using a dedicated session to avoid transaction timeouts.
-8. **Discover pubkeys**: fetch `/pubkeys.json` from the peer and create `encountered` intro lists for any unknown pubkeys, so they can be loaded later via `RUN_OPTIONAL_LOAD`.
-9. Update peer state with current `setupId`, `loadCounter`, and `fullFetchDone`.
+5. **Incremental sync**: fetch recent nanopubs via `/nanopubs.jelly?afterCounter=X`.
+6. **Discover pubkeys**: fetch `/pubkeys.json` from the peer and create `encountered` intro lists for any unknown pubkeys, so they can be loaded later via `RUN_OPTIONAL_LOAD`.
+7. Update peer state with current `setupId` and `loadCounter`.
 
 **Not yet implemented optimizations:**
 - Per-pubkey/type position tracking for incremental sync (currently downloads full lists)
@@ -202,7 +200,7 @@ Field type legend: primary# / unique* / combined-unique** / indexed^ (all with p
       { id#:'JohnDoe>d28', depth^:1, agent^:JohnDoe, pubkey^:d28, ratio:0.01 }
       ...
     peerState:
-      { id#:'https://example.com/peer/', setupId:1332309348, loadCounter:42000, fullFetchDone:true, lastChecked:1710672000000 }
+      { id#:'https://example.com/peer/', setupId:1332309348, loadCounter:42000, lastChecked:1710672000000 }
       ...
     tasks:
       { notBefore^:1710672000000, action^:CHECK_NEW }

--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -8,7 +8,6 @@ services:
 #     - REGISTRY_SERVICE_URL=https://url.of.this.registry.com/
       - REGISTRY_PEER_URLS=https://registry.petapico.org/;https://registry.knowledgepixels.com/
 #     - REGISTRY_PERFORM_FULL_LOAD=false
-#     - REGISTRY_PERFORM_FULL_FETCH=false  # Disable full fetch of all nanopubs from peers during CHECK_NEW
 #     - REGISTRY_LOAD_ALL_PUBKEYS=true  # Load all discovered pubkeys at high priority, not just trust-approved ones
 #                                       # (non-approved pubkeys are normally loaded one at a time with delays)
 #     - REGISTRY_TEST_INSTANCE=true  # Set as test instance; only has an effect on DB initialization

--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -9,6 +9,8 @@ services:
       - REGISTRY_PEER_URLS=https://registry.petapico.org/;https://registry.knowledgepixels.com/
 #     - REGISTRY_PERFORM_FULL_LOAD=false
 #     - REGISTRY_PERFORM_FULL_FETCH=false  # Disable full fetch of all nanopubs from peers during CHECK_NEW
+#     - REGISTRY_LOAD_ALL_PUBKEYS=true  # Load all discovered pubkeys at high priority, not just trust-approved ones
+#                                       # (non-approved pubkeys are normally loaded one at a time with delays)
 #     - REGISTRY_TEST_INSTANCE=true  # Set as test instance; only has an effect on DB initialization
 #     - REGISTRY_SETTING_FILE=/data/registry.trig
 #     - REGISTRY_SERVICE_URL=https://your.public.registry.url.com/

--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -8,8 +8,8 @@ services:
 #     - REGISTRY_SERVICE_URL=https://url.of.this.registry.com/
       - REGISTRY_PEER_URLS=https://registry.petapico.org/;https://registry.knowledgepixels.com/
 #     - REGISTRY_PERFORM_FULL_LOAD=false
-#     - REGISTRY_LOAD_ALL_PUBKEYS=true  # Load all discovered pubkeys at high priority, not just trust-approved ones
-#                                       # (non-approved pubkeys are normally loaded one at a time with delays)
+#     - REGISTRY_PRIORITIZE_ALL_PUBKEYS=true  # Load all discovered pubkeys at high priority, not just trust-approved ones
+#                                            # (all pubkeys are loaded eventually; this flag removes the throttling)
 #     - REGISTRY_TEST_INSTANCE=true  # Set as test instance; only has an effect on DB initialization
 #     - REGISTRY_SETTING_FILE=/data/registry.trig
 #     - REGISTRY_SERVICE_URL=https://your.public.registry.url.com/

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Monitor nanopub registry loading progress.
+#
+# Periodically polls the registry's JSON endpoint and logs key metrics as TSV.
+# Useful for tracking how fast nanopubs are loaded after a fresh start, comparing
+# configurations (e.g. with/without REGISTRY_LOAD_ALL_PUBKEYS), or watching a
+# trust update cycle.
+#
+# Columns: timestamp, elapsed seconds, server status, nanopubCount, loadCounter,
+#          accountCount, agentCount
+#
+# Usage:
+#   ./scripts/monitor.sh                          # poll every 10s, default URL
+#   ./scripts/monitor.sh 5                        # poll every 5s
+#   ./scripts/monitor.sh 10 http://host:9292      # custom registry URL
+#   ./scripts/monitor.sh 10 | tee monitor.log     # watch live + save to file
+#
+# Requirements: curl, python3
+
+set -euo pipefail
+
+INTERVAL=${1:-10}
+BASE_URL=${2:-http://localhost:9292}
+URL="${BASE_URL}/.json"
+
+printf "timestamp\tseconds\tstatus\tnanopubCount\tloadCounter\taccountCount\tagentCount\n"
+
+START=$(date +%s)
+
+while true; do
+    NOW=$(date +%s)
+    ELAPSED=$((NOW - START))
+    JSON=$(curl -sf "$URL" 2>/dev/null) || true
+    if [ -n "$JSON" ]; then
+        printf "%s\t%d\t%s\t%s\t%s\t%s\t%s\n" \
+            "$(date +%H:%M:%S)" \
+            "$ELAPSED" \
+            "$(echo "$JSON" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("status","?"))' 2>/dev/null)" \
+            "$(echo "$JSON" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("nanopubCount",0))' 2>/dev/null)" \
+            "$(echo "$JSON" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("loadCounter",0))' 2>/dev/null)" \
+            "$(echo "$JSON" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("accountCount",0))' 2>/dev/null)" \
+            "$(echo "$JSON" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("agentCount",0))' 2>/dev/null)"
+    else
+        printf "%s\t%d\t%s\n" "$(date +%H:%M:%S)" "$ELAPSED" "unreachable"
+    fi
+    sleep "$INTERVAL"
+done

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -4,7 +4,7 @@
 #
 # Periodically polls the registry's JSON endpoint and logs key metrics as TSV.
 # Useful for tracking how fast nanopubs are loaded after a fresh start, comparing
-# configurations (e.g. with/without REGISTRY_LOAD_ALL_PUBKEYS), or watching a
+# configurations (e.g. with/without REGISTRY_PRIORITIZE_ALL_PUBKEYS), or watching a
 # trust update cycle.
 #
 # Columns: timestamp, elapsed seconds, server status, nanopubCount, loadCounter,

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static com.knowledgepixels.registry.RegistryDB.*;
 
@@ -77,98 +76,27 @@ public class RegistryPeerConnector {
         Document peerState = getPeerState(s, peerUrl);
         Long lastSetupId = peerState != null ? peerState.getLong("setupId") : null;
         Long lastLoadCounter = peerState != null ? peerState.getLong("loadCounter") : null;
-        Boolean fullFetchDone = peerState != null ? peerState.getBoolean("fullFetchDone") : null;
 
         if (lastSetupId != null && !lastSetupId.equals(peerSetupId)) {
             log.info("Peer {} was reset (setupId changed), resetting tracking", peerUrl);
             deletePeerState(s, peerUrl);
             lastLoadCounter = null;
-            fullFetchDone = null;
         }
 
         if (lastLoadCounter != null && lastLoadCounter.equals(peerLoadCounter)) {
             log.info("Peer {} has no new nanopubs (loadCounter unchanged: {})", peerUrl, peerLoadCounter);
         } else if (lastLoadCounter != null) {
             // Fetch all nanopubs added since our last known position.
-            // This works for any delta size; the full fetch covers the first-sync case.
             // TODO Add per-pubkey afterCounter tracking for more targeted incremental sync
             long delta = peerLoadCounter - lastLoadCounter;
             log.info("Peer {} has {} new nanopubs, fetching recent", peerUrl, delta);
             loadRecentNanopubs(s, peerUrl, lastLoadCounter);
         } else {
-            log.info("Peer {} is new, full fetch will handle initial sync", peerUrl);
-        }
-
-        // Full fetch can be disabled once incremental sync covers all nanopubs (including non-approved pubkeys)
-        boolean fullFetchSucceeded = fullFetchDone != null && fullFetchDone;
-        if (!fullFetchSucceeded && !"false".equals(Utils.getEnv("REGISTRY_PERFORM_FULL_FETCH", ""))) {
-            Long fullFetchPosition = peerState != null ? peerState.getLong("fullFetchPosition") : null;
-            long afterCounter = fullFetchPosition != null ? fullFetchPosition : -1;
-            fullFetchSucceeded = loadAllNanopubs(s, peerUrl, afterCounter);
+            log.info("Peer {} is new, pubkey discovery will handle initial sync", peerUrl);
         }
 
         discoverPubkeys(s, peerUrl);
-        updatePeerState(s, peerUrl, peerSetupId, peerLoadCounter, fullFetchSucceeded);
-    }
-
-    private static boolean loadAllNanopubs(ClientSession s, String peerUrl, long afterCounter) {
-        String requestUrl = peerUrl + "nanopubs.jelly?afterCounter=" + afterCounter;
-        log.info("Full fetch of all nanopubs from: {} (resuming after counter {})", requestUrl, afterCounter);
-        AtomicLong lastCounter = new AtomicLong(afterCounter);
-        AtomicLong processedCount = new AtomicLong(0);
-        boolean completed = false;
-        try {
-            HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(requestUrl));
-            int httpStatus = resp.getStatusLine().getStatusCode();
-            if (httpStatus < 200 || httpStatus >= 300) {
-                EntityUtils.consumeQuietly(resp.getEntity());
-                log.info("Request failed: {} {}", requestUrl, httpStatus);
-                return false;
-            }
-            // Use a dedicated session outside any wrapping transaction to avoid
-            // MongoDB transaction timeout on large streams.
-            try (InputStream is = resp.getEntity().getContent();
-                 ClientSession loadSession = RegistryDB.getClient().startSession()) {
-                NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
-                    if (m.isSuccess()) {
-                        Nanopub np = null;
-                        try {
-                            np = m.getNanopub();
-                            RegistryDB.loadNanopub(loadSession, np);
-                            NanopubLoader.simpleLoad(loadSession, np);
-                        } catch (Exception ex) {
-                            log.warn("Skipping nanopub {} during full fetch: {}",
-                                    np != null ? np.getUri() : "unknown", ex.getMessage());
-                        }
-                    }
-                    if (m.getCounter() > 0) {
-                        lastCounter.set(m.getCounter());
-                    }
-                    long count = processedCount.incrementAndGet();
-                    if (count % 1000 == 0) {
-                        log.info("Full fetch progress: {} nanopubs processed (counter: {})", count, lastCounter.get());
-                        saveFullFetchPosition(s, peerUrl, lastCounter.get());
-                    }
-                });
-            }
-            completed = true;
-            return true;
-        } catch (Exception ex) {
-            log.info("Failed to fetch all nanopubs from {}: {}", peerUrl, ex.getMessage());
-            return false;
-        } finally {
-            if (!completed && lastCounter.get() > afterCounter) {
-                log.info("Full fetch interrupted at counter {}; saving position for resume", lastCounter.get());
-                saveFullFetchPosition(s, peerUrl, lastCounter.get());
-            }
-        }
-    }
-
-    private static void saveFullFetchPosition(ClientSession s, String peerUrl, long position) {
-        collection(Collection.PEER_STATE.toString()).updateOne(s,
-                new Document("_id", peerUrl),
-                new Document("$set", new Document("fullFetchPosition", position)),
-                new com.mongodb.client.model.UpdateOptions().upsert(true));
+        updatePeerState(s, peerUrl, peerSetupId, peerLoadCounter);
     }
 
     private static void loadRecentNanopubs(ClientSession s, String peerUrl, long afterCounter) {
@@ -238,13 +166,12 @@ public class RegistryPeerConnector {
         }
     }
 
-    static void updatePeerState(ClientSession s, String peerUrl, long setupId, long loadCounter, boolean fullFetchDone) {
+    static void updatePeerState(ClientSession s, String peerUrl, long setupId, long loadCounter) {
         collection(Collection.PEER_STATE.toString()).updateOne(s,
                 new Document("_id", peerUrl),
                 new Document("$set", new Document("_id", peerUrl)
                         .append("setupId", setupId)
                         .append("loadCounter", loadCounter)
-                        .append("fullFetchDone", fullFetchDone)
                         .append("lastChecked", System.currentTimeMillis())),
                 new com.mongodb.client.model.UpdateOptions().upsert(true));
     }

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -801,7 +801,11 @@ public enum Task implements Serializable {
                 Document df = new Document("pubkey", pubkeyHash).append("type", "$");
                 if (!has(s, "lists", df)) insert(s, "lists", df.append("status", encountered.getValue()));
 
-                schedule(s, CHECK_NEW.withDelay(500));
+                if (loadAllPubkeys()) {
+                    schedule(s, RUN_OPTIONAL_LOAD.withDelay(100));
+                } else {
+                    schedule(s, CHECK_NEW.withDelay(500));
+                }
                 return;
             }
 
@@ -819,6 +823,11 @@ public enum Task implements Serializable {
                 }
 
                 set(s, "lists", df.append("status", loaded.getValue()));
+
+                if (loadAllPubkeys()) {
+                    schedule(s, RUN_OPTIONAL_LOAD.withDelay(100));
+                    return;
+                }
             }
 
             schedule(s, CHECK_NEW.withDelay(500));
@@ -866,6 +875,10 @@ public enum Task implements Serializable {
 
     private Document with(String key, Object value) {
         return asDocument().append(key, value);
+    }
+
+    private static boolean loadAllPubkeys() {
+        return "true".equals(System.getenv("REGISTRY_LOAD_ALL_PUBKEYS"));
     }
 
     // TODO Move these to setting:

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -801,7 +801,7 @@ public enum Task implements Serializable {
                 Document df = new Document("pubkey", pubkeyHash).append("type", "$");
                 if (!has(s, "lists", df)) insert(s, "lists", df.append("status", encountered.getValue()));
 
-                if (loadAllPubkeys()) {
+                if (prioritizeAllPubkeys()) {
                     schedule(s, RUN_OPTIONAL_LOAD.withDelay(100));
                 } else {
                     schedule(s, CHECK_NEW.withDelay(500));
@@ -824,7 +824,7 @@ public enum Task implements Serializable {
 
                 set(s, "lists", df.append("status", loaded.getValue()));
 
-                if (loadAllPubkeys()) {
+                if (prioritizeAllPubkeys()) {
                     schedule(s, RUN_OPTIONAL_LOAD.withDelay(100));
                     return;
                 }
@@ -877,8 +877,8 @@ public enum Task implements Serializable {
         return asDocument().append(key, value);
     }
 
-    private static boolean loadAllPubkeys() {
-        return "true".equals(System.getenv("REGISTRY_LOAD_ALL_PUBKEYS"));
+    private static boolean prioritizeAllPubkeys() {
+        return "true".equals(System.getenv("REGISTRY_PRIORITIZE_ALL_PUBKEYS"));
     }
 
     // TODO Move these to setting:

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
@@ -103,29 +103,19 @@ class RegistryPeerConnectorTest {
 
         @Test
         void updatePeerState_createsPeerState() {
-            updatePeerState(session, "https://peer.example.com/", 123L, 42000L, true);
+            updatePeerState(session, "https://peer.example.com/", 123L, 42000L);
 
             Document state = getPeerState(session, "https://peer.example.com/");
             assertNotNull(state);
             assertEquals(123L, state.getLong("setupId"));
             assertEquals(42000L, state.getLong("loadCounter"));
-            assertTrue(state.getBoolean("fullFetchDone"));
             assertNotNull(state.getLong("lastChecked"));
         }
 
         @Test
-        void updatePeerState_storesFullFetchDoneFalse() {
-            updatePeerState(session, "https://peer.example.com/", 123L, 42000L, false);
-
-            Document state = getPeerState(session, "https://peer.example.com/");
-            assertNotNull(state);
-            assertFalse(state.getBoolean("fullFetchDone"));
-        }
-
-        @Test
         void updatePeerState_updatesExistingState() {
-            updatePeerState(session, "https://peer.example.com/", 123L, 100L, true);
-            updatePeerState(session, "https://peer.example.com/", 123L, 200L, true);
+            updatePeerState(session, "https://peer.example.com/", 123L, 100L);
+            updatePeerState(session, "https://peer.example.com/", 123L, 200L);
 
             Document state = getPeerState(session, "https://peer.example.com/");
             assertEquals(200L, state.getLong("loadCounter"));
@@ -134,7 +124,7 @@ class RegistryPeerConnectorTest {
 
         @Test
         void deletePeerState_removesState() {
-            updatePeerState(session, "https://peer.example.com/", 123L, 42000L, true);
+            updatePeerState(session, "https://peer.example.com/", 123L, 42000L);
             assertNotNull(getPeerState(session, "https://peer.example.com/"));
 
             deletePeerState(session, "https://peer.example.com/");
@@ -143,7 +133,7 @@ class RegistryPeerConnectorTest {
 
         @Test
         void syncWithPeer_skipsWhenLoadCounterUnchanged() {
-            updatePeerState(session, "https://peer.example.com/", 123L, 500L, true);
+            updatePeerState(session, "https://peer.example.com/", 123L, 500L);
 
             syncWithPeer(session, "https://peer.example.com/", 123L, 500L);
 
@@ -153,7 +143,7 @@ class RegistryPeerConnectorTest {
 
         @Test
         void syncWithPeer_resetsOnSetupIdChange() {
-            updatePeerState(session, "https://peer.example.com/", 100L, 500L, true);
+            updatePeerState(session, "https://peer.example.com/", 100L, 500L);
 
             // Sync with a different setupId — should reset and treat as new peer
             // This will try to load by pubkeys (which will find none), then update state
@@ -167,28 +157,12 @@ class RegistryPeerConnectorTest {
         @Test
         void syncWithPeer_updatesStateAfterSync() {
             // First time seeing this peer (no prior state)
-            // Full fetch will fail (no real HTTP endpoint), so fullFetchDone should be false
             syncWithPeer(session, "https://peer.example.com/", 123L, 42000L);
 
             Document state = getPeerState(session, "https://peer.example.com/");
             assertNotNull(state);
             assertEquals(123L, state.getLong("setupId"));
             assertEquals(42000L, state.getLong("loadCounter"));
-            assertFalse(state.getBoolean("fullFetchDone"),
-                    "fullFetchDone should be false when full fetch fails");
-        }
-
-        @Test
-        void syncWithPeer_preservesFullFetchDoneTrue() {
-            // Simulate a prior successful full fetch
-            updatePeerState(session, "https://peer.example.com/", 123L, 500L, true);
-
-            // Sync again with new loadCounter — fullFetchDone should remain true
-            syncWithPeer(session, "https://peer.example.com/", 123L, 600L);
-
-            Document state = getPeerState(session, "https://peer.example.com/");
-            assertTrue(state.getBoolean("fullFetchDone"),
-                    "fullFetchDone should remain true after subsequent syncs");
         }
 
         @Test
@@ -253,8 +227,8 @@ class RegistryPeerConnectorTest {
 
         @Test
         void multiplePeers_trackedIndependently() {
-            updatePeerState(session, "https://peer1.example.com/", 100L, 500L, true);
-            updatePeerState(session, "https://peer2.example.com/", 200L, 600L, true);
+            updatePeerState(session, "https://peer1.example.com/", 100L, 500L);
+            updatePeerState(session, "https://peer2.example.com/", 200L, 600L);
 
             Document state1 = getPeerState(session, "https://peer1.example.com/");
             Document state2 = getPeerState(session, "https://peer2.example.com/");


### PR DESCRIPTION
## Summary
- Adds `REGISTRY_PRIORITIZE_ALL_PUBKEYS` env var: when set to `true`, non-approved pubkeys discovered from peers are loaded at the same speed as trust-approved ones (removes throttling in `RUN_OPTIONAL_LOAD`)
- Removes `REGISTRY_PERFORM_FULL_FETCH` and the full fetch mechanism (`loadAllNanopubs`, `saveFullFetchPosition`, `fullFetchDone` tracking), since per-pubkey loading via `discoverPubkeys()` + `RUN_OPTIONAL_LOAD` provides complete coverage
- Adds `scripts/monitor.sh` for tracking registry loading progress over time

Closes #80

## Test plan
- [x] All 116 tests pass
- [x] Tested with fresh DB: `REGISTRY_PRIORITIZE_ALL_PUBKEYS=true` loads non-approved pubkeys at ~8.8 np/s vs ~0.26 np/s without the flag (34x speedup)
- [x] Verified both configurations reach the same final nanopub count

🤖 Generated with [Claude Code](https://claude.com/claude-code)