### PR TITLE
Add /get/ path that forwards to Nanodash for HTML requests

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/registry/MainVerticle.java
@@ -45,6 +45,8 @@ public class MainVerticle extends AbstractVerticle {
         router.route(HttpMethod.GET, "/pubkeys*").handler(c -> ListPage.show(c));
         router.route(HttpMethod.GET, "/np/").handler(c -> c.response().putHeader("Location", "/").setStatusCode(307).end());
         router.route(HttpMethod.GET, "/np/*").handler(c -> NanopubPage.show(c));
+        router.route(HttpMethod.GET, "/get/").handler(c -> c.response().putHeader("Location", "/").setStatusCode(307).end());
+        router.route(HttpMethod.GET, "/get/*").handler(c -> NanopubPage.show(c, true));
         router.route(HttpMethod.GET, "/debug/*").handler(c -> DebugPage.show(c));
         router.route(HttpMethod.GET, "/style.css").handler(c -> ResourcePage.show(c, "style.css", "text/css"));
 

--- a/src/main/java/com/knowledgepixels/registry/NanopubPage.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubPage.java
@@ -22,11 +22,23 @@ import static com.knowledgepixels.registry.Utils.*;
 
 public class NanopubPage extends Page {
 
+    static final String NANODASH_BASE_URL_DEFAULT = "https://nanodash.knowledgepixels.com/";
+
+    static String getNanodashBaseUrl() {
+        return Utils.getEnv("REGISTRY_NANODASH_BASE_URL", NANODASH_BASE_URL_DEFAULT);
+    }
+
+    private final boolean forwardHtml;
+
     public static void show(RoutingContext context) {
+        show(context, false);
+    }
+
+    public static void show(RoutingContext context, boolean forwardHtml) {
         NanopubPage page;
         try (ClientSession s = RegistryDB.getClient().startSession()) {
             s.startTransaction();
-            page = new NanopubPage(s, context);
+            page = new NanopubPage(s, context, forwardHtml);
             page.show();
         } catch (IOException ex) {
             ex.printStackTrace();
@@ -36,8 +48,9 @@ public class NanopubPage extends Page {
         }
     }
 
-    private NanopubPage(ClientSession mongoSession, RoutingContext context) {
+    private NanopubPage(ClientSession mongoSession, RoutingContext context, boolean forwardHtml) {
         super(mongoSession, context);
+        this.forwardHtml = forwardHtml;
     }
 
     protected void show() throws IOException {
@@ -60,8 +73,8 @@ public class NanopubPage extends Page {
             setRespContentType(format);
         }
 
-        if (req.matches("/np/RA[a-zA-Z0-9-_]{43}(\\.[a-z]+)?")) {
-            String ac = req.replaceFirst("/np/(RA[a-zA-Z0-9-_]{43})(\\.[a-z]+)?", "$1");
+        if (req.matches("/(np|get)/RA[a-zA-Z0-9-_]{43}(\\.[a-z]+)?")) {
+            String ac = req.replaceFirst("/(np|get)/(RA[a-zA-Z0-9-_]{43})(\\.[a-z]+)?", "$2");
             Document npDoc = collection(Collection.NANOPUBS.toString()).find(new Document("_id", ac)).first();
             if (npDoc == null) {
                 if (!isSet(mongoSession, Collection.SERVER_INFO.toString(), "testInstance")) {
@@ -101,6 +114,15 @@ public class NanopubPage extends Page {
                 outputNanopub(npDoc, RDFFormat.JSONLD);
             } else if (format != null && format.equals(TYPE_TRIX)) {
                 outputNanopub(npDoc, RDFFormat.TRIX);
+            } else if (forwardHtml && isHtmlRequested(c)) {
+                String fullId = npDoc.getString("fullId");
+                c.response().setStatusCode(302);
+                c.response().putHeader("Location", getNanodashBaseUrl() + "explore?id=" + Utils.urlEncode(fullId));
+                return;
+            } else if (forwardHtml) {
+                // Non-HTML default for /get/ path (e.g. Accept: */*): serve as trig
+                setRespContentType(TYPE_TRIG);
+                println(npDoc.getString("content"));
             } else {
                 printHtmlHeader("Nanopublication " + ac + " - Nanopub Registry");
                 println("<h1>Nanopublication</h1>");
@@ -130,6 +152,11 @@ public class NanopubPage extends Page {
         } else {
             c.response().setStatusCode(400).setStatusMessage("Invalid request: " + getFullRequest());
         }
+    }
+
+    private static boolean isHtmlRequested(RoutingContext c) {
+        String accept = c.request().getHeader("Accept");
+        return accept != null && accept.contains("text/html");
     }
 
     private void outputNanopub(Document npDoc, RDFFormat rdfFormat) {

--- a/src/test/java/com/knowledgepixels/registry/NanopubPageTest.java
+++ b/src/test/java/com/knowledgepixels/registry/NanopubPageTest.java
@@ -1,0 +1,142 @@
+package com.knowledgepixels.registry;
+
+import com.mongodb.MongoClient;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class NanopubPageTest {
+
+    private static final String ARTIFACT_CODE = "RAeFsphUvGCAkryLarEz5mTQm3Wk4Yx5XCi5jY3Rfkn6k";
+    private static final String FULL_ID = "https://w3id.org/np/" + ARTIFACT_CODE;
+    private static final String TRIG_CONTENT = "@prefix this: <" + FULL_ID + "> .";
+
+    private Document makeNpDoc() {
+        return new Document("_id", ARTIFACT_CODE)
+                .append("fullId", FULL_ID)
+                .append("content", TRIG_CONTENT);
+    }
+
+    @Test
+    void getPathWithHtmlAcceptRedirectsToNanodash() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            HttpServerResponse response = setupMocks(dbMock, "/get/" + ARTIFACT_CODE, "text/html", true, makeNpDoc());
+            verify(response).setStatusCode(302);
+            verify(response).putHeader("Location",
+                    NanopubPage.NANODASH_BASE_URL_DEFAULT + "explore?id=" + Utils.urlEncode(FULL_ID));
+        }
+    }
+
+    @Test
+    void getPathWithTrigExtensionReturnsTrig() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            HttpServerResponse response = setupMocks(dbMock, "/get/" + ARTIFACT_CODE + ".trig", null, true, makeNpDoc());
+            verify(response, never()).setStatusCode(302);
+            verify(response).write(TRIG_CONTENT + "\n");
+        }
+    }
+
+    @Test
+    void npPathWithHtmlRendersPage() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            HttpServerResponse response = setupMocks(dbMock, "/np/" + ARTIFACT_CODE, "text/html", false, makeNpDoc());
+            verify(response, never()).setStatusCode(302);
+            verify(response).write("<!DOCTYPE HTML>\n");
+        }
+    }
+
+    @Test
+    void getPathWithNoAcceptHeaderDefaultsToTrig() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            // No Accept header: format defaults to first in SUPPORTED_TYPES_NANOPUB (application/trig)
+            // so no redirect happens — trig is served
+            HttpServerResponse response = setupMocks(dbMock, "/get/" + ARTIFACT_CODE, null, true, makeNpDoc());
+            verify(response, never()).setStatusCode(302);
+            verify(response).write(TRIG_CONTENT + "\n");
+        }
+    }
+
+    @Test
+    void getPathWithWildcardAcceptDefaultsToTrig() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            // Accept: */* (curl default) should serve trig, not redirect
+            HttpServerResponse response = setupMocks(dbMock, "/get/" + ARTIFACT_CODE, "*/*", true, makeNpDoc());
+            verify(response, never()).setStatusCode(302);
+            verify(response).write(TRIG_CONTENT + "\n");
+        }
+    }
+
+    @Test
+    void getPathWithTrigAcceptReturnsTrig() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            HttpServerResponse response = setupMocks(dbMock, "/get/" + ARTIFACT_CODE, "application/trig", true, makeNpDoc());
+            verify(response, never()).setStatusCode(302);
+            verify(response).write(TRIG_CONTENT + "\n");
+        }
+    }
+
+    @Test
+    void getPathNotFoundOnNonTestInstanceRedirects() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            HttpServerResponse response = setupMocks(dbMock, "/get/" + ARTIFACT_CODE, "text/html", true, null);
+            verify(response).setStatusCode(307);
+            verify(response).putHeader("Location", "https://np.knowledgepixels.com/" + ARTIFACT_CODE);
+        }
+    }
+
+    @Test
+    void getPathWithCustomNanodashUrl() {
+        String customUrl = "https://custom.nanodash.example.org/";
+        com.knowledgepixels.registry.utils.FakeEnv fakeEnv = com.knowledgepixels.registry.utils.FakeEnv.getInstance();
+        fakeEnv.addVariable("REGISTRY_NANODASH_BASE_URL", customUrl).build();
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            HttpServerResponse response = setupMocks(dbMock, "/get/" + ARTIFACT_CODE, "text/html", true, makeNpDoc());
+            verify(response).setStatusCode(302);
+            verify(response).putHeader("Location",
+                    customUrl + "explore?id=" + Utils.urlEncode(FULL_ID));
+        } finally {
+            fakeEnv.reset();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private HttpServerResponse setupMocks(MockedStatic<RegistryDB> dbMock, String path, String acceptHeader, boolean forwardHtml, Document npDoc) {
+        MongoClient mongoClient = mock(MongoClient.class);
+        ClientSession session = mock(ClientSession.class);
+        dbMock.when(RegistryDB::getClient).thenReturn(mongoClient);
+        when(mongoClient.startSession()).thenReturn(session);
+
+        MongoCollection<Document> collection = mock(MongoCollection.class);
+        FindIterable<Document> findIterable = mock(FindIterable.class);
+        dbMock.when(() -> RegistryDB.collection(Collection.NANOPUBS.toString())).thenReturn(collection);
+        when(collection.find(any(Document.class))).thenReturn(findIterable);
+        when(findIterable.first()).thenReturn(npDoc);
+
+        RoutingContext context = mock(RoutingContext.class);
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        HttpServerResponse response = mock(HttpServerResponse.class);
+        when(context.request()).thenReturn(request);
+        when(context.response()).thenReturn(response);
+        when(request.path()).thenReturn(path);
+        when(request.getHeader("Accept")).thenReturn(acceptHeader);
+        when(response.setChunked(anyBoolean())).thenReturn(response);
+        when(response.putHeader(anyString(), anyString())).thenReturn(response);
+        when(response.setStatusCode(anyInt())).thenReturn(response);
+        when(response.setStatusMessage(anyString())).thenReturn(response);
+        when(response.write(anyString())).thenReturn(null);
+
+        NanopubPage.show(context, forwardHtml);
+
+        return response;
+    }
+
+}


### PR DESCRIPTION
## Summary
- Adds a `/get/` endpoint that behaves like `/np/` for all RDF formats (trig, jelly, JSON-LD, N-Quads, TRIX)
- When `text/html` is explicitly requested (e.g. browser), redirects (302) to Nanodash to display the nanopublication
- When `Accept: */*` (e.g. curl) or no Accept header is sent, defaults to serving trig — no redirect
- The Nanodash base URL is configurable via `REGISTRY_NANODASH_BASE_URL` env var (default: `https://nanodash.knowledgepixels.com/`)

Closes #82

## Test plan
- [x] 8 unit tests added in `NanopubPageTest` covering:
  - `/get/` + `Accept: text/html` → 302 redirect to Nanodash
  - `/get/` + `Accept: */*` → serves trig (no redirect)
  - `/get/` + no Accept header → serves trig
  - `/get/` + `Accept: application/trig` → serves trig
  - `/get/` + `.trig` extension → serves trig
  - `/np/` + `Accept: text/html` → renders HTML page (no redirect)
  - `/get/` + not found → 307 redirect to np.knowledgepixels.com
  - `/get/` + custom `REGISTRY_NANODASH_BASE_URL` → uses custom URL
- [x] All 123 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)