### PR TITLE
Stop pushing nanopubs to legacy server and skip test-instance peers

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/registry/MainVerticle.java
@@ -17,7 +17,6 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubImpl;
-import org.nanopub.extra.server.PublishNanopub;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,16 +87,6 @@ public class MainVerticle extends AbstractVerticle {
                                     throw new RuntimeException("Nanopublication not supported: " + np.getUri());
                                 // Load to lists, if applicable:
                                 NanopubLoader.simpleLoad(s, np);
-
-                                if (!isSet(s, Collection.SERVER_INFO.toString(), "testInstance")) {
-                                    // Here we publish it also to the first-generation services, so they know about it too:
-                                    // TODO Remove this at some point
-                                    try {
-                                        new PublishNanopub().publishNanopub(np, "https://np.knowledgepixels.com/");
-                                    } catch (Exception ex) {
-                                        ex.printStackTrace();
-                                    }
-                                }
                             }
                         }
                     }

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -56,6 +56,11 @@ public class RegistryPeerConnector {
             return;
         }
 
+        if (isTestInstance(resp)) {
+            log.info("Skipping peer {} because it is a test instance", peerUrl);
+            return;
+        }
+
         String status = getHeader(resp, "Nanopub-Registry-Status");
         if (!"ready".equals(status) && !"updating".equals(status)) {
             log.info("Peer {} in non-ready state: {}", peerUrl, status);
@@ -178,6 +183,10 @@ public class RegistryPeerConnector {
 
     static void deletePeerState(ClientSession s, String peerUrl) {
         collection(Collection.PEER_STATE.toString()).deleteOne(s, new Document("_id", peerUrl));
+    }
+
+    static boolean isTestInstance(HttpResponse resp) {
+        return "true".equals(getHeader(resp, "Nanopub-Registry-Test-Instance"));
     }
 
     static String getHeader(HttpResponse resp, String name) {

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
@@ -68,6 +68,24 @@ class RegistryPeerConnectorTest {
             HttpResponse resp = makeResponse("Nanopub-Registry-Load-Counter", "notanumber");
             assertNull(getHeaderLong(resp, "Nanopub-Registry-Load-Counter"));
         }
+
+        @Test
+        void isTestInstance_returnsTrueWhenHeaderIsTrue() {
+            HttpResponse resp = makeResponse("Nanopub-Registry-Test-Instance", "true");
+            assertTrue(isTestInstance(resp));
+        }
+
+        @Test
+        void isTestInstance_returnsFalseWhenHeaderIsFalse() {
+            HttpResponse resp = makeResponse("Nanopub-Registry-Test-Instance", "false");
+            assertFalse(isTestInstance(resp));
+        }
+
+        @Test
+        void isTestInstance_returnsFalseWhenHeaderMissing() {
+            HttpResponse resp = makeResponse();
+            assertFalse(isTestInstance(resp));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Remove the legacy forward of published nanopubs to `np.knowledgepixels.com` (and the unused `PublishNanopub` import)
- Skip peers that advertise `Nanopub-Registry-Test-Instance: true` during registry-to-registry sync
- Add tests for the new `isTestInstance` header check

## Test plan
- [x] All 127 existing + new tests pass
- [ ] Verify production registries no longer forward to `np.knowledgepixels.com` on publish
- [ ] Verify test-instance peers are skipped during sync (check logs for "Skipping peer ... because it is a test instance")

🤖 Generated with [Claude Code](https://claude.com/claude-code)