### PR TITLE
Fix peer sync stalling due to MongoDB transaction timeout

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/ListPage.java
+++ b/src/main/java/com/knowledgepixels/registry/ListPage.java
@@ -29,14 +29,14 @@ public class ListPage extends Page {
     public static void show(RoutingContext context) {
         ListPage page;
         try (ClientSession s = RegistryDB.getClient().startSession()) {
-            s.startTransaction();
+            // No transaction here: the nanopubs.jelly endpoint streams large result sets
+            // that would exceed MongoDB's transaction timeout.
             page = new ListPage(s, context);
             page.show();
         } catch (IOException ex) {
             ex.printStackTrace();
         } finally {
             context.response().end();
-            // TODO Clean-up here?
         }
     }
 
@@ -301,8 +301,6 @@ public class ListPage extends Page {
                     context.response().setStatusCode(400).setStatusMessage("Invalid afterCounter parameter.");
                     return;
                 }
-                // TODO: something is aborting the Mongo transaction here after a while,
-                //  find out what exactly.
                 var pipeline = collection(Collection.NANOPUBS.toString()).find(mongoSession).filter(gt("counter", afterCounter)).sort(ascending("counter"))
                         // Only include the needed fields to save bandwidth to the DB
                         .projection(include("jelly", "counter"));

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.knowledgepixels.registry.RegistryDB.*;
 
@@ -88,6 +89,8 @@ public class RegistryPeerConnector {
             lastLoadCounter = null;
         }
 
+        long effectiveLoadCounter = lastLoadCounter != null ? lastLoadCounter : 0;
+
         if (lastLoadCounter != null && lastLoadCounter.equals(peerLoadCounter)) {
             log.info("Peer {} has no new nanopubs (loadCounter unchanged: {})", peerUrl, peerLoadCounter);
         } else if (lastLoadCounter != null) {
@@ -95,25 +98,33 @@ public class RegistryPeerConnector {
             // TODO Add per-pubkey afterCounter tracking for more targeted incremental sync
             long delta = peerLoadCounter - lastLoadCounter;
             log.info("Peer {} has {} new nanopubs, fetching recent", peerUrl, delta);
-            loadRecentNanopubs(s, peerUrl, lastLoadCounter);
+            long lastReceived = loadRecentNanopubs(s, peerUrl, lastLoadCounter);
+            if (lastReceived > 0) {
+                effectiveLoadCounter = lastReceived;
+            }
         } else {
             log.info("Peer {} is new, pubkey discovery will handle initial sync", peerUrl);
         }
 
         discoverPubkeys(s, peerUrl);
-        updatePeerState(s, peerUrl, peerSetupId, peerLoadCounter);
+        updatePeerState(s, peerUrl, peerSetupId, effectiveLoadCounter);
     }
 
-    private static void loadRecentNanopubs(ClientSession s, String peerUrl, long afterCounter) {
+    /**
+     * Fetches nanopubs from a peer after the given counter.
+     * @return the counter of the last successfully received nanopub, or -1 if none were received
+     */
+    private static long loadRecentNanopubs(ClientSession s, String peerUrl, long afterCounter) {
         String requestUrl = peerUrl + "nanopubs.jelly?afterCounter=" + afterCounter;
         log.info("Fetching recent nanopubs from: {}", requestUrl);
+        AtomicLong lastReceivedCounter = new AtomicLong(-1);
         try {
             HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(requestUrl));
             int httpStatus = resp.getStatusLine().getStatusCode();
             if (httpStatus < 200 || httpStatus >= 300) {
                 EntityUtils.consumeQuietly(resp.getEntity());
                 log.info("Request failed: {} {}", requestUrl, httpStatus);
-                return;
+                return -1;
             }
             try (InputStream is = resp.getEntity().getContent()) {
                 NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
@@ -123,6 +134,9 @@ public class RegistryPeerConnector {
                             np = m.getNanopub();
                             RegistryDB.loadNanopub(s, np);
                             NanopubLoader.simpleLoad(s, np);
+                            if (m.getCounter() > 0) {
+                                lastReceivedCounter.set(m.getCounter());
+                            }
                         } catch (Exception ex) {
                             log.warn("Skipping nanopub {} during recent fetch: {}",
                                     np != null ? np.getUri() : "unknown", ex.getMessage());
@@ -133,6 +147,8 @@ public class RegistryPeerConnector {
         } catch (IOException ex) {
             log.info("Failed to fetch recent nanopubs from {}: {}", peerUrl, ex.getMessage());
         }
+        log.info("Last received counter from {}: {}", peerUrl, lastReceivedCounter.get());
+        return lastReceivedCounter.get();
     }
 
     static void discoverPubkeys(ClientSession s, String peerUrl) {

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
@@ -169,7 +169,8 @@ class RegistryPeerConnectorTest {
 
             Document state = getPeerState(session, "https://peer.example.com/");
             assertEquals(200L, state.getLong("setupId"));
-            assertEquals(600L, state.getLong("loadCounter"));
+            // After reset, no nanopubs were actually received, so loadCounter stays at 0
+            assertEquals(0L, state.getLong("loadCounter"));
         }
 
         @Test
@@ -180,7 +181,8 @@ class RegistryPeerConnectorTest {
             Document state = getPeerState(session, "https://peer.example.com/");
             assertNotNull(state);
             assertEquals(123L, state.getLong("setupId"));
-            assertEquals(42000L, state.getLong("loadCounter"));
+            // No nanopubs were actually received, so loadCounter reflects that
+            assertEquals(0L, state.getLong("loadCounter"));
         }
 
         @Test


### PR DESCRIPTION
## Summary
- **Server**: Remove MongoDB transaction from `ListPage`, which hosts the `nanopubs.jelly` endpoint. The 60-second transaction timeout was killing cursors mid-stream when serving large result sets (50k+ nanopubs), truncating the response.
- **Client**: Track the actual last received counter from the jelly stream (via `MaybeNanopub.getCounter()`) instead of blindly recording the peer's advertised load counter. This ensures interrupted transfers resume from the correct position on the next sync cycle.

## Context
Observed in [nanopub-ecosystem-test-infra](https://github.com/knowledgepixels/nanopub-ecosystem-test-infra): registries running v1.4.0 stop syncing at 50k–76k nanopubs. The root cause is that after a truncated transfer, `updatePeerState` recorded the peer's full load counter, so subsequent syncs believed everything was already fetched.

## Test plan
- [x] All 127 tests pass (updated 2 existing tests to reflect new counter-tracking behavior)
- [ ] Deploy to test infra and verify registries sync past 76k nanopubs
- [ ] Verify `nanopubs.jelly` endpoint streams full result sets without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)