### PR TITLE
perf: eliminate redundant signature verification in POST and peer sync

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/registry/MainVerticle.java
@@ -63,7 +63,7 @@ public class MainVerticle extends AbstractVerticle {
 
         Handler<RoutingContext> postHandler = c -> {
             c.request().bodyHandler(bh -> {
-                try {
+                vertx.<Void>executeBlocking(() -> {
                     String contentType = c.request().getHeader("Content-Type");
                     Nanopub np = null;
                     try {
@@ -81,21 +81,28 @@ public class MainVerticle extends AbstractVerticle {
 
                                 // TODO Run checks here whether we want to register this nanopub (considering quotas etc.)
 
+                                // Verify signature once, pass through to avoid redundant verification:
+                                String pubkey = RegistryDB.getPubkey(np);
+                                if (pubkey == null)
+                                    throw new RuntimeException("Nanopublication not supported: " + np.getUri());
                                 // Load to nanopub store:
-                                boolean success = RegistryDB.loadNanopub(s, np);
+                                boolean success = RegistryDB.loadNanopubVerified(s, np, pubkey, null);
                                 if (!success)
                                     throw new RuntimeException("Nanopublication not supported: " + np.getUri());
                                 // Load to lists, if applicable:
-                                NanopubLoader.simpleLoad(s, np);
+                                NanopubLoader.simpleLoad(s, np, pubkey);
                             }
                         }
                     }
-                    c.response().setStatusCode(201);
-                } catch (Exception ex) {
-                    c.response().setStatusCode(400).setStatusMessage("Error processing nanopub: " + ex.getMessage());
-                } finally {
-                    c.response().end();
-                }
+                    return null;
+                }).onComplete(ar -> {
+                    if (ar.succeeded()) {
+                        c.response().setStatusCode(201).end();
+                    } else {
+                        c.response().setStatusCode(400)
+                                .setStatusMessage("Error processing nanopub: " + ar.cause().getMessage()).end();
+                    }
+                });
             });
         };
         router.route(HttpMethod.POST, "/").handler(postHandler);

--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -65,12 +65,20 @@ public class NanopubLoader {
             log.info("Ignore (not signed): {}", np.getUri());
             return;
         }
-        String pubkeyHash = Utils.getHash(pubkey);
+        simpleLoad(mongoSession, np, pubkey);
+    }
+
+    /**
+     * Loads a nanopub to the appropriate lists, using a pre-verified public key
+     * to skip redundant signature verification.
+     */
+    public static void simpleLoad(ClientSession mongoSession, Nanopub np, String verifiedPubkey) {
+        String pubkeyHash = Utils.getHash(verifiedPubkey);
         // TODO Do we need to load anything else here, into the other DB collections?
         if (has(mongoSession, "lists", new Document("pubkey", pubkeyHash).append("type", "$").append("status", "loaded"))) {
-            RegistryDB.loadNanopub(mongoSession, np, pubkeyHash, "$");
+            RegistryDB.loadNanopubVerified(mongoSession, np, verifiedPubkey, pubkeyHash, "$");
         } else if (has(mongoSession, "lists", new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH).append("status", "loaded"))) {
-            RegistryDB.loadNanopub(mongoSession, np, pubkeyHash, INTRO_TYPE, ENDORSE_TYPE);
+            RegistryDB.loadNanopubVerified(mongoSession, np, verifiedPubkey, pubkeyHash, INTRO_TYPE, ENDORSE_TYPE);
         } else if (!has(mongoSession, "lists", new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH))) {
             // Unknown pubkey: create encountered intro list so RUN_OPTIONAL_LOAD picks it up
             try {

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -11,6 +11,8 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.CountOptions;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.ReturnDocument;
 import com.mongodb.client.model.UpdateOptions;
 import net.trustyuri.TrustyUriUtils;
 import org.bson.Document;
@@ -92,10 +94,10 @@ public class RegistryDB {
         mongoDB = mongoClient.getDatabase(REGISTRY_DB_NAME);
 
         try (ClientSession mongoSession = mongoClient.startSession()) {
-            if (isInitialized(mongoSession)) {
-                return;
+            if (!isInitialized(mongoSession)) {
+                IndexInitializer.initCollections(mongoSession);
             }
-            IndexInitializer.initCollections(mongoSession);
+            initNanopubCounter(mongoSession);
         }
     }
 
@@ -333,6 +335,35 @@ public class RegistryDB {
     }
 
     /**
+     * Initializes the nanopub counter document to the current maximum counter value
+     * in the nanopubs collection. Uses $max to ensure the counter is never decreased.
+     * Safe to call on every startup.
+     */
+    private static void initNanopubCounter(ClientSession mongoSession) {
+        Long maxCounter = (Long) getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "counter");
+        if (maxCounter == null) maxCounter = 0L;
+        collection("counters").updateOne(mongoSession,
+                new Document("_id", "nanopubs"),
+                new Document("$max", new Document("value", maxCounter)),
+                new UpdateOptions().upsert(true));
+        logger.info("Nanopub counter initialized to {}", maxCounter);
+    }
+
+    /**
+     * Atomically increments and returns the next nanopub counter value.
+     * Eliminates the read-then-write race condition that previously caused
+     * duplicate key errors on the counter index under concurrent load.
+     */
+    private static long getNextNanopubCounter(ClientSession mongoSession) {
+        Document result = collection("counters").findOneAndUpdate(
+                mongoSession,
+                new Document("_id", "nanopubs"),
+                new Document("$inc", new Document("value", 1L)),
+                new FindOneAndUpdateOptions().upsert(true).returnDocument(ReturnDocument.AFTER));
+        return result.getLong("value");
+    }
+
+    /**
      * Loads a nanopublication into the database.
      *
      * @param mongoSession the MongoDB client session
@@ -352,6 +383,19 @@ public class RegistryDB {
      * @return true if the nanopublication was loaded, false otherwise
      */
     public static boolean loadNanopub(ClientSession mongoSession, Nanopub nanopub, String pubkeyHash, String... types) {
+        String pubkey = getPubkey(nanopub);
+        if (pubkey == null) {
+            logger.info("Ignoring invalid nanopub: {}", nanopub.getUri());
+            return false;
+        }
+        return loadNanopubVerified(mongoSession, nanopub, pubkey, pubkeyHash, types);
+    }
+
+    /**
+     * Loads a nanopublication with a pre-verified public key, skipping signature verification.
+     * Use this when the caller has already verified the signature via getPubkey().
+     */
+    static boolean loadNanopubVerified(ClientSession mongoSession, Nanopub nanopub, String verifiedPubkey, String pubkeyHash, String... types) {
         if (nanopub.getTripleCount() > 1200) {
             logger.info("Nanopub has too many triples ({}): {}", nanopub.getTripleCount(), nanopub.getUri());
             return false;
@@ -378,17 +422,12 @@ public class RegistryDB {
                 return false;
             }
         }
-        String pubkey = getPubkey(nanopub);
-        if (pubkey == null) {
-            logger.info("Ignoring invalid nanopub: {}", nanopub.getUri());
-            return false;
-        }
-        String ph = Utils.getHash(pubkey);
+        String ph = Utils.getHash(verifiedPubkey);
         if (pubkeyHash != null && !pubkeyHash.equals(ph)) {
             logger.info("Ignoring nanopub with non-matching pubkey: {}", nanopub.getUri());
             return false;
         }
-        recordHash(mongoSession, pubkey);
+        recordHash(mongoSession, verifiedPubkey);
 
         String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
         if (ac == null) {
@@ -399,8 +438,6 @@ public class RegistryDB {
         if (has(mongoSession, Collection.NANOPUBS.toString(), ac)) {
             logger.debug("Already loaded: {}", nanopub.getUri());
         } else {
-            Long counter = (Long) getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "counter");
-            if (counter == null) counter = 0l;
             String nanopubString;
             byte[] jellyContent;
             try {
@@ -410,22 +447,33 @@ public class RegistryDB {
             } catch (IOException ex) {
                 throw new RuntimeException(ex);
             }
-            collection(Collection.NANOPUBS.toString()).insertOne(mongoSession, new Document("_id", ac).append("fullId", nanopub.getUri().stringValue()).append("counter", counter + 1).append("pubkey", ph).append("content", nanopubString).append("jelly", new Binary(jellyContent)));
+            long counter = getNextNanopubCounter(mongoSession);
+            boolean inserted = false;
+            try {
+                collection(Collection.NANOPUBS.toString()).insertOne(mongoSession, new Document("_id", ac).append("fullId", nanopub.getUri().stringValue()).append("counter", counter).append("pubkey", ph).append("content", nanopubString).append("jelly", new Binary(jellyContent)));
+                inserted = true;
+            } catch (MongoWriteException e) {
+                if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
+                // Another thread inserted this nanopub concurrently — safe to skip
+                logger.debug("Already loaded (concurrent): {}", nanopub.getUri());
+            }
 
-            for (IRI invalidatedId : Utils.getInvalidatedNanopubIds(nanopub)) {
-                String invalidatedAc = TrustyUriUtils.getArtifactCode(invalidatedId.stringValue());
-                if (invalidatedAc == null) continue;  // This should never happen; checking here just to be sure
+            if (inserted) {
+                for (IRI invalidatedId : Utils.getInvalidatedNanopubIds(nanopub)) {
+                    String invalidatedAc = TrustyUriUtils.getArtifactCode(invalidatedId.stringValue());
+                    if (invalidatedAc == null) continue;  // This should never happen; checking here just to be sure
 
-                // Add this nanopub also to all lists of invalidated nanopubs:
-                collection("invalidations").insertOne(mongoSession, new Document("invalidatingNp", ac).append("invalidatingPubkey", ph).append("invalidatedNp", invalidatedAc));
-                MongoCursor<Document> invalidatedEntries = collection("listEntries").find(mongoSession, new Document("np", invalidatedAc).append("pubkey", ph)).cursor();
-                while (invalidatedEntries.hasNext()) {
-                    Document invalidatedEntry = invalidatedEntries.next();
-                    addToList(mongoSession, nanopub, ph, invalidatedEntry.getString("type"));
+                    // Add this nanopub also to all lists of invalidated nanopubs:
+                    collection("invalidations").insertOne(mongoSession, new Document("invalidatingNp", ac).append("invalidatingPubkey", ph).append("invalidatedNp", invalidatedAc));
+                    MongoCursor<Document> invalidatedEntries = collection("listEntries").find(mongoSession, new Document("np", invalidatedAc).append("pubkey", ph)).cursor();
+                    while (invalidatedEntries.hasNext()) {
+                        Document invalidatedEntry = invalidatedEntries.next();
+                        addToList(mongoSession, nanopub, ph, invalidatedEntry.getString("type"));
+                    }
+
+                    collection("listEntries").updateMany(mongoSession, new Document("np", invalidatedAc).append("pubkey", ph), new Document("$set", new Document("invalidated", true)));
+                    collection("trustEdges").updateMany(mongoSession, new Document("source", invalidatedAc), new Document("$set", new Document("invalidated", true)));
                 }
-
-                collection("listEntries").updateMany(mongoSession, new Document("np", invalidatedAc).append("pubkey", ph), new Document("$set", new Document("invalidated", true)));
-                collection("trustEdges").updateMany(mongoSession, new Document("source", invalidatedAc), new Document("$set", new Document("invalidated", true)));
             }
         }
 
@@ -477,18 +525,31 @@ public class RegistryDB {
         if (has(mongoSession, "listEntries", new Document("pubkey", pubkeyHash).append("type", typeHash).append("np", ac))) {
             logger.debug("Already listed: {}", nanopub.getUri());
         } else {
-
-            Document doc = getMaxValueDocument(mongoSession, "listEntries", new Document("pubkey", pubkeyHash).append("type", typeHash), "position");
-            long position;
-            String checksum;
-            if (doc == null) {
-                position = 0l;
-                checksum = NanopubUtils.updateXorChecksum(nanopub.getUri(), NanopubUtils.INIT_CHECKSUM);
-            } else {
-                position = doc.getLong("position") + 1;
-                checksum = NanopubUtils.updateXorChecksum(nanopub.getUri(), doc.getString("checksum"));
+            for (int attempt = 0; ; attempt++) {
+                Document doc = getMaxValueDocument(mongoSession, "listEntries", new Document("pubkey", pubkeyHash).append("type", typeHash), "position");
+                long position;
+                String checksum;
+                if (doc == null) {
+                    position = 0l;
+                    checksum = NanopubUtils.updateXorChecksum(nanopub.getUri(), NanopubUtils.INIT_CHECKSUM);
+                } else {
+                    position = doc.getLong("position") + 1;
+                    checksum = NanopubUtils.updateXorChecksum(nanopub.getUri(), doc.getString("checksum"));
+                }
+                try {
+                    collection("listEntries").insertOne(mongoSession, new Document("pubkey", pubkeyHash).append("type", typeHash).append("position", position).append("np", ac).append("checksum", checksum).append("invalidated", false));
+                    break;
+                } catch (MongoWriteException e) {
+                    if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
+                    if (has(mongoSession, "listEntries", new Document("pubkey", pubkeyHash).append("type", typeHash).append("np", ac))) {
+                        break; // Already listed by concurrent thread
+                    }
+                    // Position collision — retry with updated position
+                    if (attempt >= 100) {
+                        throw new RuntimeException("Failed to insert list entry after " + (attempt + 1) + " attempts");
+                    }
+                }
             }
-            collection("listEntries").insertOne(mongoSession, new Document("pubkey", pubkeyHash).append("type", typeHash).append("position", position).append("np", ac).append("checksum", checksum).append("invalidated", false));
         }
     }
 

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -132,8 +132,11 @@ public class RegistryPeerConnector {
                         Nanopub np = null;
                         try {
                             np = m.getNanopub();
-                            RegistryDB.loadNanopub(s, np);
-                            NanopubLoader.simpleLoad(s, np);
+                            String pubkey = RegistryDB.getPubkey(np);
+                            if (pubkey != null) {
+                                RegistryDB.loadNanopubVerified(s, np, pubkey, null);
+                                NanopubLoader.simpleLoad(s, np, pubkey);
+                            }
                             if (m.getCounter() > 0) {
                                 lastReceivedCounter.set(m.getCounter());
                             }

--- a/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
@@ -21,6 +21,8 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.mongodb.MongoDBContainer;
 
+import net.trustyuri.TrustyUriUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Calendar;
@@ -465,6 +467,114 @@ class RegistryDBTest {
         String nonExistingHash = Utils.getHash("anotherValue");
         retrievedValue = RegistryDB.unhash(nonExistingHash);
         assertNull(retrievedValue);
+    }
+
+    @Test
+    void loadNanopubVerifiedStoresNanopub() throws MalformedNanopubException, IOException {
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        File file = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+        Nanopub nanopub = new NanopubImpl(file);
+        String pubkey = RegistryDB.getPubkey(nanopub);
+        assertNotNull(pubkey);
+
+        // Load via the verified path (skips signature re-verification)
+        assertTrue(RegistryDB.loadNanopubVerified(session, nanopub, pubkey, null));
+
+        // Verify nanopub is stored in the database
+        String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
+        assertTrue(RegistryDB.has(session, Collection.NANOPUBS.toString(), ac));
+
+        // Verify counter was assigned
+        Document doc = RegistryDB.collection(Collection.NANOPUBS.toString()).find(session, new Document("_id", ac)).first();
+        assertNotNull(doc);
+        assertTrue(doc.getLong("counter") > 0);
+        assertEquals(Utils.getHash(pubkey), doc.getString("pubkey"));
+    }
+
+    @Test
+    void loadNanopubVerifiedMatchesLoadNanopub() throws MalformedNanopubException, IOException {
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        File file = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+        Nanopub nanopub = new NanopubImpl(file);
+        String pubkey = RegistryDB.getPubkey(nanopub);
+
+        // Load via verified path
+        assertTrue(RegistryDB.loadNanopubVerified(session, nanopub, pubkey, null));
+
+        String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
+        Document doc = RegistryDB.collection(Collection.NANOPUBS.toString()).find(session, new Document("_id", ac)).first();
+        assertNotNull(doc);
+
+        // Verify the stored fields match what loadNanopub would produce
+        assertEquals(nanopub.getUri().stringValue(), doc.getString("fullId"));
+        assertEquals(Utils.getHash(pubkey), doc.getString("pubkey"));
+        assertNotNull(doc.getString("content"));
+        assertNotNull(doc.get("jelly"));
+    }
+
+    @Test
+    void loadNanopubVerifiedSkipsDuplicates() throws MalformedNanopubException, IOException {
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        File file = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+        Nanopub nanopub = new NanopubImpl(file);
+        String pubkey = RegistryDB.getPubkey(nanopub);
+
+        // Load twice — second call should succeed without error
+        assertTrue(RegistryDB.loadNanopubVerified(session, nanopub, pubkey, null));
+        assertTrue(RegistryDB.loadNanopubVerified(session, nanopub, pubkey, null));
+
+        // Only one document in the collection
+        String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
+        assertEquals(1, RegistryDB.collection(Collection.NANOPUBS.toString())
+                .countDocuments(session, new Document("_id", ac)));
+    }
+
+    @Test
+    void simpleLoadWithVerifiedPubkeyCreatesListEntries() throws MalformedNanopubException, IOException {
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        File file = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+        Nanopub nanopub = new NanopubImpl(file);
+        String pubkey = RegistryDB.getPubkey(nanopub);
+        String pubkeyHash = Utils.getHash(pubkey);
+
+        // Store the nanopub first
+        RegistryDB.loadNanopubVerified(session, nanopub, pubkey, null);
+
+        // simpleLoad should create an encountered list entry for unknown pubkeys
+        NanopubLoader.simpleLoad(session, nanopub, pubkey);
+
+        // Verify that a list was created for this pubkey (encountered status for unknown pubkey)
+        assertTrue(RegistryDB.has(session, "lists",
+                new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH)));
+    }
+
+    @Test
+    void simpleLoadWithVerifiedPubkeyMatchesSimpleLoad() throws MalformedNanopubException, IOException {
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        File file = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+        Nanopub nanopub = new NanopubImpl(file);
+        String pubkey = RegistryDB.getPubkey(nanopub);
+        String pubkeyHash = Utils.getHash(pubkey);
+
+        // Store via verified path then simpleLoad with pubkey
+        RegistryDB.loadNanopubVerified(session, nanopub, pubkey, null);
+        NanopubLoader.simpleLoad(session, nanopub, pubkey);
+
+        // Capture the state created by the verified path
+        Document listDoc = RegistryDB.collection("lists").find(session,
+                new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH)).first();
+        assertNotNull(listDoc);
+        assertEquals(EntryStatus.encountered.getValue(), listDoc.getString("status"));
     }
 
 }


### PR DESCRIPTION
## Summary

- **Verify signature once per nanopub** instead of 3 times in the POST handler and peer sync paths. Cryptographic signature verification (`SignatureUtils.hasValidSignature`) is CPU-intensive; reducing from 3x to 1x directly cuts POST latency.
- **New `loadNanopubVerified()`** (package-private): accepts a pre-verified pubkey, skipping the `getPubkey()` call. Public `loadNanopub()` API unchanged for all existing callers (Task.java, etc.).
- **New `simpleLoad()` overload** accepting verified pubkey, calling `loadNanopubVerified()` internally.
- **POST handler moved to `vertx.executeBlocking()`**: blocking I/O (MongoDB, RDF parsing, crypto) no longer stalls the Vert.x event loop thread, improving concurrent request throughput.
- **RegistryPeerConnector** updated with the same verify-once pattern.
- Also includes the atomic counter fix from PR #87.

## Test plan

- [x] All 132 tests pass (127 existing + 5 new)
- [x] New tests cover: `loadNanopubVerified` storage, field correctness, idempotency, and `simpleLoad` with verified pubkey
- [ ] Deploy and verify POST latency improvement under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)