### PR TITLE
perf: parallel stream loading, batched task scheduling, skip idle peer discovery

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -34,6 +34,12 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static com.knowledgepixels.registry.RegistryDB.has;
@@ -88,6 +94,71 @@ public class NanopubLoader {
             } catch (MongoWriteException e) {
                 if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
             }
+        }
+    }
+
+    private static final int LOAD_PARALLELISM = Integer.parseInt(
+            Utils.getEnv("REGISTRY_LOAD_PARALLELISM", String.valueOf(Runtime.getRuntime().availableProcessors())));
+
+    /**
+     * Processes a stream of nanopubs in parallel using a thread pool.
+     * Each worker thread uses its own MongoDB ClientSession.
+     * Backpressure is applied via a semaphore to avoid unbounded memory growth.
+     *
+     * @param stream    the nanopub stream to process
+     * @param processor consumer that processes each nanopub (called with its own ClientSession)
+     */
+    public static void loadStreamInParallel(Stream<MaybeNanopub> stream, Consumer<Nanopub> processor) {
+        if (LOAD_PARALLELISM <= 1) {
+            // Fall back to sequential processing
+            stream.forEach(m -> {
+                if (!m.isSuccess()) throw new AbortingTaskException("Failed to download nanopub; aborting task...");
+                processor.accept(m.getNanopub());
+            });
+            return;
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(LOAD_PARALLELISM);
+        Semaphore semaphore = new Semaphore(LOAD_PARALLELISM * 2);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        try {
+            stream.forEach(m -> {
+                if (error.get() != null) return;
+                if (!m.isSuccess()) {
+                    error.compareAndSet(null, new AbortingTaskException("Failed to download nanopub; aborting task..."));
+                    return;
+                }
+                Nanopub np = m.getNanopub();
+                try {
+                    semaphore.acquire();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    error.compareAndSet(null, e);
+                    return;
+                }
+                executor.submit(() -> {
+                    try {
+                        processor.accept(np);
+                    } catch (Exception e) {
+                        error.compareAndSet(null, e);
+                    } finally {
+                        semaphore.release();
+                    }
+                });
+            });
+        } finally {
+            executor.shutdown();
+            try {
+                executor.awaitTermination(1, TimeUnit.HOURS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        if (error.get() != null) {
+            if (error.get() instanceof RuntimeException re) throw re;
+            throw new RuntimeException("Parallel loading failed", error.get());
         }
     }
 

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -102,11 +102,12 @@ public class RegistryPeerConnector {
             if (lastReceived > 0) {
                 effectiveLoadCounter = lastReceived;
             }
+            // Only discover new pubkeys when the peer has new data
+            discoverPubkeys(s, peerUrl);
         } else {
             log.info("Peer {} is new, pubkey discovery will handle initial sync", peerUrl);
+            discoverPubkeys(s, peerUrl);
         }
-
-        discoverPubkeys(s, peerUrl);
         updatePeerState(s, peerUrl, peerSetupId, effectiveLoadCounter);
     }
 
@@ -127,25 +128,22 @@ public class RegistryPeerConnector {
                 return -1;
             }
             try (InputStream is = resp.getEntity().getContent()) {
-                NanopubStream.fromByteStream(is).getAsNanopubs().forEach(m -> {
-                    if (m.isSuccess()) {
-                        Nanopub np = null;
-                        try {
-                            np = m.getNanopub();
-                            String pubkey = RegistryDB.getPubkey(np);
-                            if (pubkey != null) {
-                                RegistryDB.loadNanopubVerified(s, np, pubkey, null);
-                                NanopubLoader.simpleLoad(s, np, pubkey);
-                            }
-                            if (m.getCounter() > 0) {
+                NanopubLoader.loadStreamInParallel(
+                        NanopubStream.fromByteStream(is).getAsNanopubs().peek(m -> {
+                            // Track counter in the main thread as items are consumed from the stream
+                            if (m.isSuccess() && m.getCounter() > 0) {
                                 lastReceivedCounter.set(m.getCounter());
                             }
-                        } catch (Exception ex) {
-                            log.warn("Skipping nanopub {} during recent fetch: {}",
-                                    np != null ? np.getUri() : "unknown", ex.getMessage());
-                        }
-                    }
-                });
+                        }),
+                        np -> {
+                            try (ClientSession workerSession = RegistryDB.getClient().startSession()) {
+                                String pubkey = RegistryDB.getPubkey(np);
+                                if (pubkey != null) {
+                                    RegistryDB.loadNanopubVerified(workerSession, np, pubkey, null);
+                                    NanopubLoader.simpleLoad(workerSession, np, pubkey);
+                                }
+                            }
+                        });
             }
         } catch (IOException ex) {
             log.info("Failed to fetch recent nanopubs from {}: {}", peerUrl, ex.getMessage());

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -411,10 +411,10 @@ public enum Task implements Serializable {
 
                 String coreIntroChecksums = buildChecksumFallbacks(s, pubkeyHash, INTRO_TYPE_HASH);
                 try (var stream = NanopubLoader.retrieveNanopubsFromPeers(INTRO_TYPE_HASH, pubkeyHash, coreIntroChecksums)) {
-                    stream.forEach(m -> {
-                        if (!m.isSuccess())
-                            throw new AbortingTaskException("Failed to download nanopub; aborting task...");
-                        loadNanopub(s, m.getNanopub(), pubkeyHash, INTRO_TYPE);
+                    NanopubLoader.loadStreamInParallel(stream, np -> {
+                        try (ClientSession ws = RegistryDB.getClient().startSession()) {
+                            loadNanopub(ws, np, pubkeyHash, INTRO_TYPE);
+                        }
                     });
                 }
 
@@ -741,11 +741,11 @@ public enum Task implements Serializable {
                     try (var stream = NanopubLoader.retrieveNanopubsFromPeers("$", ph, checksums)) {
                         long startTime = System.nanoTime();
                         AtomicLong loaded = new AtomicLong(0);
-                        stream.forEach(m -> {
-                            if (!m.isSuccess())
-                                throw new AbortingTaskException("Failed to download nanopub; aborting task...");
-                            loadNanopub(s, m.getNanopub(), ph, "$");
-                            loaded.incrementAndGet();
+                        NanopubLoader.loadStreamInParallel(stream, np -> {
+                            try (ClientSession ws = RegistryDB.getClient().startSession()) {
+                                loadNanopub(ws, np, ph, "$");
+                                loaded.incrementAndGet();
+                            }
                         });
                         double timeSeconds = (System.nanoTime() - startTime) * 1e-9;
                         log.info("Loaded {} nanopubs in {}s, {} np/s",
@@ -770,29 +770,40 @@ public enum Task implements Serializable {
     },
 
     RUN_OPTIONAL_LOAD {
+
+        private static final int BATCH_SIZE = Integer.parseInt(
+                Utils.getEnv("REGISTRY_OPTIONAL_LOAD_BATCH_SIZE", "100"));
+
         public void run(ClientSession s, Document taskDoc) {
-            Document di = getOne(s, "lists", new Document("type", INTRO_TYPE_HASH).append("status", encountered.getValue()));
-            if (di != null) {
+            AtomicLong totalLoaded = new AtomicLong(0);
+
+            // Phase 1: Process encountered intro lists (core loading)
+            while (totalLoaded.get() < BATCH_SIZE) {
+                Document di = getOne(s, "lists", new Document("type", INTRO_TYPE_HASH).append("status", encountered.getValue()));
+                if (di == null) break;
+
                 final String pubkeyHash = di.getString("pubkey");
                 Validate.notNull(pubkeyHash);
                 log.info("Optional core loading: {}", pubkeyHash);
 
                 String introChecksums = buildChecksumFallbacks(s, pubkeyHash, INTRO_TYPE_HASH);
                 try (var stream = NanopubLoader.retrieveNanopubsFromPeers(INTRO_TYPE_HASH, pubkeyHash, introChecksums)) {
-                    stream.forEach(m -> {
-                        if (!m.isSuccess())
-                            throw new AbortingTaskException("Failed to download nanopub; aborting task...");
-                        loadNanopub(s, m.getNanopub(), pubkeyHash, INTRO_TYPE);
+                    NanopubLoader.loadStreamInParallel(stream, np -> {
+                        try (ClientSession ws = RegistryDB.getClient().startSession()) {
+                            loadNanopub(ws, np, pubkeyHash, INTRO_TYPE);
+                            totalLoaded.incrementAndGet();
+                        }
                     });
                 }
                 set(s, "lists", di.append("status", loaded.getValue()));
 
                 String endorseChecksums = buildChecksumFallbacks(s, pubkeyHash, ENDORSE_TYPE_HASH);
                 try (var stream = NanopubLoader.retrieveNanopubsFromPeers(ENDORSE_TYPE_HASH, pubkeyHash, endorseChecksums)) {
-                    stream.forEach(m -> {
-                        if (!m.isSuccess())
-                            throw new AbortingTaskException("Failed to download nanopub; aborting task...");
-                        loadNanopub(s, m.getNanopub(), pubkeyHash, ENDORSE_TYPE);
+                    NanopubLoader.loadStreamInParallel(stream, np -> {
+                        try (ClientSession ws = RegistryDB.getClient().startSession()) {
+                            loadNanopub(ws, np, pubkeyHash, ENDORSE_TYPE);
+                            totalLoaded.incrementAndGet();
+                        }
                     });
                 }
 
@@ -805,38 +816,48 @@ public enum Task implements Serializable {
 
                 Document df = new Document("pubkey", pubkeyHash).append("type", "$");
                 if (!has(s, "lists", df)) insert(s, "lists", df.append("status", encountered.getValue()));
-
-                if (prioritizeAllPubkeys()) {
-                    schedule(s, CHECK_NEW.withDelay(100));
-                } else {
-                    schedule(s, CHECK_NEW.withDelay(500));
-                }
-                return;
             }
 
-            Document df = getOne(s, "lists", new Document("type", "$").append("status", encountered.getValue()));
-            if (df != null) {
+            // Phase 2: Process encountered full lists (if budget remains)
+            while (totalLoaded.get() < BATCH_SIZE) {
+                Document df = getOne(s, "lists", new Document("type", "$").append("status", encountered.getValue()));
+                if (df == null) break;
+
                 final String pubkeyHash = df.getString("pubkey");
                 log.info("Optional full loading: {}", pubkeyHash);
 
                 String fullChecksums = buildChecksumFallbacks(s, pubkeyHash, "$");
                 try (var stream = NanopubLoader.retrieveNanopubsFromPeers("$", pubkeyHash, fullChecksums)) {
-                    stream.forEach(m -> {
-                        if (!m.isSuccess())
-                            throw new AbortingTaskException("Failed to download nanopub; aborting task...");
-                        loadNanopub(s, m.getNanopub(), pubkeyHash, "$");
+                    NanopubLoader.loadStreamInParallel(stream, np -> {
+                        try (ClientSession ws = RegistryDB.getClient().startSession()) {
+                            loadNanopub(ws, np, pubkeyHash, "$");
+                            totalLoaded.incrementAndGet();
+                        }
                     });
                 }
 
                 set(s, "lists", df.append("status", loaded.getValue()));
-
-                if (prioritizeAllPubkeys()) {
-                    schedule(s, CHECK_NEW.withDelay(100));
-                    return;
-                }
             }
 
-            schedule(s, CHECK_NEW.withDelay(500));
+            if (totalLoaded.get() > 0) {
+                log.info("Optional load batch completed: {} nanopubs across multiple pubkeys", totalLoaded.get());
+            }
+
+            if (prioritizeAllPubkeys()) {
+                // Check if there are more pubkeys waiting to be processed
+                boolean moreWork = has(s, "lists", new Document("type", INTRO_TYPE_HASH).append("status", encountered.getValue()))
+                        || has(s, "lists", new Document("type", "$").append("status", encountered.getValue()));
+                if (moreWork) {
+                    // Continue processing without a full CHECK_NEW cycle in between.
+                    // CHECK_NEW will run naturally once all encountered lists are processed.
+                    schedule(s, RUN_OPTIONAL_LOAD.withDelay(10));
+                } else {
+                    schedule(s, CHECK_NEW.withDelay(500));
+                }
+            } else {
+                // Throttled: yield to CHECK_NEW after each batch to prioritize approved pubkeys
+                schedule(s, CHECK_NEW.withDelay(500));
+            }
         }
 
     },


### PR DESCRIPTION
## Summary

Three improvements targeting replication throughput and steady-state latency:

- **Parallel nanopub stream loading**: New `loadStreamInParallel()` utility processes nanopub streams with a configurable thread pool (`REGISTRY_LOAD_PARALLELISM`, defaults to CPU cores). Each worker uses its own MongoDB ClientSession. Backpressure via semaphore prevents unbounded memory growth. Applied to `loadRecentNanopubs`, `LOAD_FULL`, `LOAD_CORE` intro path, and `RUN_OPTIONAL_LOAD`.

- **Batched `RUN_OPTIONAL_LOAD`**: Processes multiple pubkeys per task cycle until ~100 nanopubs loaded (`REGISTRY_OPTIONAL_LOAD_BATCH_SIZE`), instead of one pubkey per cycle with a full CHECK_NEW round-trip in between. When `REGISTRY_PRIORITIZE_ALL_PUBKEYS` is set, self-schedules directly while work remains. Without the flag, yields to CHECK_NEW after each batch (throttled).

- **Skip `discoverPubkeys` when peer has no new data**: `discoverPubkeys` (HTTP GET `pubkeys.json`) was called for every peer every CHECK_NEW cycle, even when the peer's loadCounter was unchanged. Now only called when the peer actually has new nanopubs or is newly discovered. This dramatically reduces steady-state CHECK_NEW latency.

## Test plan

- [x] All 138 tests pass
- [ ] Deploy and verify: initial sync throughput improved with parallel loading
- [ ] Verify steady-state: new nanopub detection within 1-2 seconds
- [ ] Verify `REGISTRY_PRIORITIZE_ALL_PUBKEYS=true` processes pubkeys in rapid batches
- [ ] Verify without the flag: pubkey loading is throttled, yields to CHECK_NEW

🤖 Generated with [Claude Code](https://claude.com/claude-code)