### PR TITLE
perf: batch seqNum allocation to reduce global counter contention

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/ListPage.java
+++ b/src/main/java/com/knowledgepixels/registry/ListPage.java
@@ -315,16 +315,19 @@ public class ListPage extends Page {
             }
         } else if (req.equals("/nanopubs")) {
             if (TYPE_JELLY.equals(format)) {
-                // Return all nanopubs from after counter X (-1 by default)
-                long afterCounter;
+                // Return all nanopubs after seqNum X (-1 by default)
+                // TODO(transition): Remove afterCounter fallback after all peers upgraded
+                long afterSeqNum;
                 try {
-                    afterCounter = Long.parseLong(getParam("afterCounter", "-1"));
+                    afterSeqNum = Long.parseLong(getParam("afterSeqNum",
+                            getParam("afterCounter", "-1")));
                 } catch (NumberFormatException ex) {
-                    context.response().setStatusCode(400).setStatusMessage("Invalid afterCounter parameter.");
+                    context.response().setStatusCode(400).setStatusMessage("Invalid afterSeqNum parameter.");
                     return;
                 }
-                var pipeline = collection(Collection.NANOPUBS.toString()).find(mongoSession).filter(gt("counter", afterCounter)).sort(ascending("counter"))
-                        // Only include the needed fields to save bandwidth to the DB
+                var pipeline = collection(Collection.NANOPUBS.toString()).find(mongoSession).filter(gt("seqNum", afterSeqNum)).sort(ascending("seqNum"))
+                        // TODO(transition): Change "counter" to "seqNum" once nanopub-java library is updated
+                        // NanopubStream.fromMongoCursorWithCounter reads the hardcoded "counter" field
                         .projection(include("jelly", "counter"));
 
                 try (var result = pipeline.cursor()) {
@@ -345,9 +348,9 @@ public class ListPage extends Page {
                         filter = afterId.isEmpty() ? new Document() : gt("_id", afterId);
                         sort = ascending("_id");
                     } else {
-                        // sort=date (default): latest first, using indexed counter field
+                        // sort=date (default): latest first, using indexed seqNum field
                         filter = new Document();
-                        sort = descending("counter");
+                        sort = descending("seqNum");
                     }
                     try (MongoCursor<Document> c = collection(Collection.NANOPUBS.toString()).find(mongoSession)
                             .filter(filter).sort(sort)
@@ -380,7 +383,7 @@ public class ListPage extends Page {
                     println("<h3>Latest Nanopubs (max. 1000)</h3>");
                     println("<ol>");
                     try (MongoCursor<Document> c = collection(Collection.NANOPUBS.toString()).find(mongoSession)
-                            .sort(descending("counter")).limit(1000).cursor()) {
+                            .sort(descending("seqNum")).limit(1000).cursor()) {
                         while (c.hasNext()) {
                             String npId = c.next().getString("_id");
                             println("<li><a href=\"/np/" + npId + "\"><code>" + getLabel(npId) + "</code></a></li>");

--- a/src/main/java/com/knowledgepixels/registry/MainPage.java
+++ b/src/main/java/com/knowledgepixels/registry/MainPage.java
@@ -67,7 +67,8 @@ public class MainPage extends Page {
             println("<li><em>coverageTypes:</em> " + getValue(mongoSession, Collection.SERVER_INFO.toString(), "coverageTypes") + "</li>");
             println("<li><em>coverageAgents:</em> " + getValue(mongoSession, Collection.SERVER_INFO.toString(), "coverageAgents") + "</li>");
             println("<li><em>status:</em> " + status + "</li>");
-            println("<li><em>loadCounter:</em> " + getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "counter") + "</li>");
+            println("<li><em>seqNum:</em> " + getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "seqNum") + "</li>");
+            println("<li><em>nanopubCount:</em> " + collection(Collection.NANOPUBS.toString()).estimatedDocumentCount() + "</li>");
             println("<li><em>trustStateCounter:</em> " + getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateCounter") + "</li>");
             Object lastTimeUpdate = getValue(mongoSession, Collection.SERVER_INFO.toString(), "lastTrustStateUpdate");
             if (lastTimeUpdate != null) {
@@ -101,7 +102,7 @@ public class MainPage extends Page {
             }
 
             println("<h3>Nanopubs</h3>");
-            println("<p>Count: " + getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "counter") + "</p>");
+            println("<p>Count: " + collection(Collection.NANOPUBS.toString()).estimatedDocumentCount() + "</p>");
             println("<p><a href=\"/nanopubs\">&gt; nanopubs</a></pi>");
             printHtmlFooter();
         }

--- a/src/main/java/com/knowledgepixels/registry/MetricsCollector.java
+++ b/src/main/java/com/knowledgepixels/registry/MetricsCollector.java
@@ -16,6 +16,9 @@ import static com.knowledgepixels.registry.RegistryDB.*;
 public final class MetricsCollector {
 
     private final Logger logger = LoggerFactory.getLogger(MetricsCollector.class);
+    private final AtomicInteger seqNum = new AtomicInteger(0);
+    private final AtomicInteger nanopubCount = new AtomicInteger(0);
+    // TODO(transition): Remove loadCounter metric after dashboards updated
     private final AtomicInteger loadCounter = new AtomicInteger(0);
     private final AtomicInteger trustStateCounter = new AtomicInteger(0);
     private final AtomicInteger agentCount = new AtomicInteger(0);
@@ -25,6 +28,9 @@ public final class MetricsCollector {
 
     public MetricsCollector(MeterRegistry meterRegistry) {
         // Numeric metrics
+        Gauge.builder("registry.seqnum", seqNum, AtomicInteger::get).register(meterRegistry);
+        Gauge.builder("registry.nanopub.count", nanopubCount, AtomicInteger::get).register(meterRegistry);
+        // TODO(transition): Remove after dashboards updated
         Gauge.builder("registry.load.counter", loadCounter, AtomicInteger::get).register(meterRegistry);
         Gauge.builder("registry.trust.state.counter", trustStateCounter, AtomicInteger::get).register(meterRegistry);
         Gauge.builder("registry.agent.count", agentCount, AtomicInteger::get).register(meterRegistry);
@@ -44,8 +50,12 @@ public final class MetricsCollector {
     public void updateMetrics() {
         try (final var session = RegistryDB.getClient().startSession()) {
             // Update numeric metrics
-            extractMaximalIntegerValueFromField(session, Collection.NANOPUBS.toString(), "counter")
-                    .ifPresent(loadCounter::set);
+            extractMaximalIntegerValueFromField(session, Collection.NANOPUBS.toString(), "seqNum")
+                    .ifPresent(val -> {
+                        seqNum.set(val);
+                        loadCounter.set(val); // TODO(transition): Remove after dashboards updated
+                    });
+            nanopubCount.set((int) collection(Collection.NANOPUBS.toString()).estimatedDocumentCount());
 
             extractIntegerValueFromField(session, Collection.SERVER_INFO.toString(), "trustStateCounter")
                     .ifPresent(trustStateCounter::set);

--- a/src/main/java/com/knowledgepixels/registry/Page.java
+++ b/src/main/java/com/knowledgepixels/registry/Page.java
@@ -40,7 +40,12 @@ public abstract class Page {
         context.response().putHeader("Nanopub-Registry-Trust-State-Counter", getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateCounter") + "");
         context.response().putHeader("Nanopub-Registry-Last-Trust-State-Update", getValue(mongoSession, Collection.SERVER_INFO.toString(), "lastTrustStateUpdate") + "");
         context.response().putHeader("Nanopub-Registry-Trust-State-Hash", getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateHash") + "");
-        context.response().putHeader("Nanopub-Registry-Load-Counter", getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "counter") + "");
+        context.response().putHeader("Nanopub-Registry-SeqNum", getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "seqNum") + "");
+        context.response().putHeader("Nanopub-Registry-Nanopub-Count", collection(Collection.NANOPUBS.toString()).estimatedDocumentCount() + "");
+        // TODO(transition): Remove after all peers upgraded
+        // Must send max(seqNum) here, not document count — old peers use Load-Counter as a cursor
+        // value for afterCounter, not just a count. Sending the count would cause re-fetching.
+        context.response().putHeader("Nanopub-Registry-Load-Counter", getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "seqNum") + "");
         context.response().putHeader("Nanopub-Registry-Test-Instance", String.valueOf(isSet(mongoSession, Collection.SERVER_INFO.toString(), "testInstance")));
 
         String r = context.request().path().substring(1);

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -97,7 +97,7 @@ public class RegistryDB {
             if (!isInitialized(mongoSession)) {
                 IndexInitializer.initCollections(mongoSession);
             }
-            initNanopubCounter(mongoSession);
+            initSeqNumCounter(mongoSession);
         }
     }
 
@@ -312,10 +312,15 @@ public class RegistryDB {
      */
     public static void recordHash(ClientSession mongoSession, String value) {
         String hash = Utils.getHash(value);
-        collection("hashes").updateOne(mongoSession,
-                new Document("value", value),
-                new Document("$setOnInsert", new Document("value", value).append("hash", hash)),
-                new UpdateOptions().upsert(true));
+        try {
+            collection("hashes").updateOne(mongoSession,
+                    new Document("value", value),
+                    new Document("$setOnInsert", new Document("value", value).append("hash", hash)),
+                    new UpdateOptions().upsert(true));
+        } catch (MongoWriteException e) {
+            // Concurrent upsert race: another thread inserted the same hash — safe to ignore
+            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
+        }
     }
 
     /**
@@ -333,33 +338,55 @@ public class RegistryDB {
         }
     }
 
+    private static final int SEQ_NUM_BATCH_SIZE = Integer.parseInt(
+            Utils.getEnv("REGISTRY_SEQ_NUM_BATCH_SIZE", "20"));
+
     /**
-     * Initializes the nanopub counter document to the current maximum counter value
-     * in the nanopubs collection. Uses $max to ensure the counter is never decreased.
-     * Safe to call on every startup.
+     * Thread-local batch range for seqNum allocation: [nextToUse, endExclusive).
+     * Each thread claims a batch of SEQ_NUM_BATCH_SIZE sequence numbers from MongoDB,
+     * then hands them out locally with zero contention until the batch is exhausted.
      */
-    private static void initNanopubCounter(ClientSession mongoSession) {
+    private static final ThreadLocal<long[]> seqNumRange = new ThreadLocal<>();
+
+    /**
+     * Initializes the seqNum counter document to the current maximum seqNum value
+     * in the nanopubs collection. Also checks legacy "counter" field for migration.
+     * Uses $max to ensure the counter is never decreased. Safe to call on every startup.
+     */
+    private static void initSeqNumCounter(ClientSession mongoSession) {
+        Long maxSeqNum = (Long) getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "seqNum");
+        // TODO(transition): Remove counter fallback after all peers upgraded
         Long maxCounter = (Long) getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "counter");
-        if (maxCounter == null) maxCounter = 0L;
+        long effective = Math.max(
+                maxSeqNum != null ? maxSeqNum : 0L,
+                maxCounter != null ? maxCounter : 0L);
         collection("counters").updateOne(mongoSession,
                 new Document("_id", "nanopubs"),
-                new Document("$max", new Document("value", maxCounter)),
+                new Document("$max", new Document("value", effective)),
                 new UpdateOptions().upsert(true));
-        logger.info("Nanopub counter initialized to {}", maxCounter);
+        logger.info("SeqNum counter initialized to {}", effective);
     }
 
     /**
-     * Atomically increments and returns the next nanopub counter value.
-     * Eliminates the read-then-write race condition that previously caused
-     * duplicate key errors on the counter index under concurrent load.
+     * Returns the next sequence number for a nanopub, using thread-local batch
+     * allocation to reduce MongoDB contention. Each thread claims SEQ_NUM_BATCH_SIZE
+     * numbers at once, then hands them out locally.
      */
-    private static long getNextNanopubCounter(ClientSession mongoSession) {
+    private static long getNextSeqNum(ClientSession mongoSession) {
+        long[] range = seqNumRange.get();
+        if (range != null && range[0] < range[1]) {
+            return range[0]++;
+        }
+        // Allocate a new batch from MongoDB
         Document result = collection("counters").findOneAndUpdate(
                 mongoSession,
                 new Document("_id", "nanopubs"),
-                new Document("$inc", new Document("value", 1L)),
+                new Document("$inc", new Document("value", (long) SEQ_NUM_BATCH_SIZE)),
                 new FindOneAndUpdateOptions().upsert(true).returnDocument(ReturnDocument.AFTER));
-        return result.getLong("value");
+        long batchEnd = result.getLong("value");
+        long batchStart = batchEnd - SEQ_NUM_BATCH_SIZE + 1;
+        seqNumRange.set(new long[]{batchStart + 1, batchEnd + 1});
+        return batchStart;
     }
 
     /**
@@ -446,10 +473,11 @@ public class RegistryDB {
             } catch (IOException ex) {
                 throw new RuntimeException(ex);
             }
-            long counter = getNextNanopubCounter(mongoSession);
+            long seqNum = getNextSeqNum(mongoSession);
             boolean inserted = false;
             try {
-                collection(Collection.NANOPUBS.toString()).insertOne(mongoSession, new Document("_id", ac).append("fullId", nanopub.getUri().stringValue()).append("counter", counter).append("pubkey", ph).append("content", nanopubString).append("jelly", new Binary(jellyContent)));
+                // TODO(transition): Remove "counter" field after all peers upgraded
+                collection(Collection.NANOPUBS.toString()).insertOne(mongoSession, new Document("_id", ac).append("fullId", nanopub.getUri().stringValue()).append("seqNum", seqNum).append("counter", seqNum).append("pubkey", ph).append("content", nanopubString).append("jelly", new Binary(jellyContent)));
                 inserted = true;
             } catch (MongoWriteException e) {
                 if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;

--- a/src/main/java/com/knowledgepixels/registry/RegistryInfo.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryInfo.java
@@ -24,6 +24,8 @@ public class RegistryInfo implements Serializable {
     private Long agentCount;
     private Long accountCount;
     private Long nanopubCount;
+    private Long seqNum;
+    // TODO(transition): Remove loadCounter after all peers upgraded
     private Long loadCounter;
     private Boolean isTestInstance;
 
@@ -35,7 +37,9 @@ public class RegistryInfo implements Serializable {
         ri.trustStateCounter = (Long) getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateCounter");
         ri.lastTrustStateUpdate = (String) getValue(mongoSession, Collection.SERVER_INFO.toString(), "lastTrustStateUpdate");
         ri.trustStateHash = (String) getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateHash");
-        ri.loadCounter = (Long) getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "counter");
+        ri.seqNum = (Long) getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "seqNum");
+        // TODO(transition): Remove loadCounter after all peers upgraded
+        ri.loadCounter = ri.seqNum;
         ri.status = (String) getValue(mongoSession, Collection.SERVER_INFO.toString(), "status");
         ri.coverageTypes = (String) getValue(mongoSession, Collection.SERVER_INFO.toString(), "coverageTypes");
         ri.coverageAgents = (String) getValue(mongoSession, Collection.SERVER_INFO.toString(), "coverageAgents");

--- a/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryPeerConnector.java
@@ -69,38 +69,44 @@ public class RegistryPeerConnector {
         }
 
         Long peerSetupId = getHeaderLong(resp, "Nanopub-Registry-Setup-Id");
-        Long peerLoadCounter = getHeaderLong(resp, "Nanopub-Registry-Load-Counter");
-        if (peerSetupId == null || peerLoadCounter == null) {
-            log.info("Peer {} missing setupId or loadCounter headers", peerUrl);
+        // TODO(transition): Remove Load-Counter fallback after all peers upgraded
+        Long peerSeqNum = getHeaderLong(resp, "Nanopub-Registry-SeqNum");
+        if (peerSeqNum == null) {
+            peerSeqNum = getHeaderLong(resp, "Nanopub-Registry-Load-Counter");
+        }
+        if (peerSetupId == null || peerSeqNum == null) {
+            log.info("Peer {} missing setupId or seqNum headers", peerUrl);
             return;
         }
 
-        syncWithPeer(s, peerUrl, peerSetupId, peerLoadCounter);
+        syncWithPeer(s, peerUrl, peerSetupId, peerSeqNum);
     }
 
-    static void syncWithPeer(ClientSession s, String peerUrl, long peerSetupId, long peerLoadCounter) {
+    static void syncWithPeer(ClientSession s, String peerUrl, long peerSetupId, long peerSeqNum) {
         Document peerState = getPeerState(s, peerUrl);
         Long lastSetupId = peerState != null ? peerState.getLong("setupId") : null;
-        Long lastLoadCounter = peerState != null ? peerState.getLong("loadCounter") : null;
+        // TODO(transition): Remove loadCounter fallback after all peers upgraded
+        Long lastSeqNum = peerState != null ? peerState.getLong("seqNum") : null;
+        if (lastSeqNum == null && peerState != null) {
+            lastSeqNum = peerState.getLong("loadCounter");
+        }
 
         if (lastSetupId != null && !lastSetupId.equals(peerSetupId)) {
             log.info("Peer {} was reset (setupId changed), resetting tracking", peerUrl);
             deletePeerState(s, peerUrl);
-            lastLoadCounter = null;
+            lastSeqNum = null;
         }
 
-        long effectiveLoadCounter = lastLoadCounter != null ? lastLoadCounter : 0;
+        long effectiveSeqNum = lastSeqNum != null ? lastSeqNum : 0;
 
-        if (lastLoadCounter != null && lastLoadCounter.equals(peerLoadCounter)) {
-            log.info("Peer {} has no new nanopubs (loadCounter unchanged: {})", peerUrl, peerLoadCounter);
-        } else if (lastLoadCounter != null) {
+        if (lastSeqNum != null && lastSeqNum.equals(peerSeqNum)) {
+            log.info("Peer {} has no new nanopubs (seqNum unchanged: {})", peerUrl, peerSeqNum);
+        } else if (lastSeqNum != null) {
             // Fetch all nanopubs added since our last known position.
-            // TODO Add per-pubkey afterCounter tracking for more targeted incremental sync
-            long delta = peerLoadCounter - lastLoadCounter;
-            log.info("Peer {} has {} new nanopubs, fetching recent", peerUrl, delta);
-            long lastReceived = loadRecentNanopubs(s, peerUrl, lastLoadCounter);
+            log.info("Peer {} has new nanopubs (seqNum {} -> {}), fetching recent", peerUrl, lastSeqNum, peerSeqNum);
+            long lastReceived = loadRecentNanopubs(s, peerUrl, lastSeqNum);
             if (lastReceived > 0) {
-                effectiveLoadCounter = lastReceived;
+                effectiveSeqNum = lastReceived;
             }
             // Only discover new pubkeys when the peer has new data
             discoverPubkeys(s, peerUrl);
@@ -108,15 +114,16 @@ public class RegistryPeerConnector {
             log.info("Peer {} is new, pubkey discovery will handle initial sync", peerUrl);
             discoverPubkeys(s, peerUrl);
         }
-        updatePeerState(s, peerUrl, peerSetupId, effectiveLoadCounter);
+        updatePeerState(s, peerUrl, peerSetupId, effectiveSeqNum);
     }
 
     /**
-     * Fetches nanopubs from a peer after the given counter.
-     * @return the counter of the last successfully received nanopub, or -1 if none were received
+     * Fetches nanopubs from a peer after the given seqNum.
+     * @return the seqNum of the last successfully received nanopub, or -1 if none were received
      */
-    private static long loadRecentNanopubs(ClientSession s, String peerUrl, long afterCounter) {
-        String requestUrl = peerUrl + "nanopubs.jelly?afterCounter=" + afterCounter;
+    private static long loadRecentNanopubs(ClientSession s, String peerUrl, long afterSeqNum) {
+        // TODO(transition): Remove afterCounter param after all peers upgraded
+        String requestUrl = peerUrl + "nanopubs.jelly?afterSeqNum=" + afterSeqNum + "&afterCounter=" + afterSeqNum;
         log.info("Fetching recent nanopubs from: {}", requestUrl);
         AtomicLong lastReceivedCounter = new AtomicLong(-1);
         try {
@@ -188,12 +195,14 @@ public class RegistryPeerConnector {
         }
     }
 
-    static void updatePeerState(ClientSession s, String peerUrl, long setupId, long loadCounter) {
+    static void updatePeerState(ClientSession s, String peerUrl, long setupId, long seqNum) {
         collection(Collection.PEER_STATE.toString()).updateOne(s,
                 new Document("_id", peerUrl),
                 new Document("$set", new Document("_id", peerUrl)
                         .append("setupId", setupId)
-                        .append("loadCounter", loadCounter)
+                        .append("seqNum", seqNum)
+                        // TODO(transition): Remove loadCounter after all peers upgraded
+                        .append("loadCounter", seqNum)
                         .append("lastChecked", System.currentTimeMillis())),
                 new com.mongodb.client.model.UpdateOptions().upsert(true));
     }

--- a/src/main/java/com/knowledgepixels/registry/db/IndexInitializer.java
+++ b/src/main/java/com/knowledgepixels/registry/db/IndexInitializer.java
@@ -29,6 +29,8 @@ public final class IndexInitializer {
         collection(Collection.TASKS.toString()).createIndex(mongoSession, Indexes.descending("not-before"));
 
         collection(Collection.NANOPUBS.toString()).createIndex(mongoSession, ascending("fullId"), unique);
+        collection(Collection.NANOPUBS.toString()).createIndex(mongoSession, descending("seqNum"), unique);
+        // TODO(transition): Remove counter index after all peers upgraded
         collection(Collection.NANOPUBS.toString()).createIndex(mongoSession, descending("counter"), unique);
         collection(Collection.NANOPUBS.toString()).createIndex(mongoSession, ascending("pubkey"));
 

--- a/src/test/java/com/knowledgepixels/registry/PageTest.java
+++ b/src/test/java/com/knowledgepixels/registry/PageTest.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.registry;
 
 import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoCollection;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -10,13 +11,22 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 class PageTest {
 
+    @SuppressWarnings("unchecked")
+    private static void mockCollectionForEstimatedCount(MockedStatic<RegistryDB> registry) {
+        MongoCollection<?> mockCollection = mock(MongoCollection.class);
+        when(mockCollection.estimatedDocumentCount()).thenReturn(0L);
+        registry.when(() -> RegistryDB.collection(anyString())).thenReturn((MongoCollection) mockCollection);
+    }
+
     @Test
     void construct() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -36,7 +46,8 @@ class PageTest {
 
     @Test
     void getFullRequest() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -56,7 +67,8 @@ class PageTest {
 
     @Test
     void getContext() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -75,7 +87,8 @@ class PageTest {
 
     @Test
     void getPresentationFormatHTML() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -94,7 +107,8 @@ class PageTest {
 
     @Test
     void getPresentationFormatPlainText() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -114,7 +128,8 @@ class PageTest {
     @Test
     void getExtension() {
         String expectedExtension = ".trig";
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -133,7 +148,8 @@ class PageTest {
 
     @Test
     void getExtensionNull() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -152,7 +168,8 @@ class PageTest {
 
     @Test
     void getRequestString() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -183,7 +200,8 @@ class PageTest {
 
     @Test
     void hasArtifactCode() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -214,7 +232,8 @@ class PageTest {
 
     @Test
     void getArtifactCodeWhenExists() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -234,7 +253,8 @@ class PageTest {
 
     @Test
     void getArtifactCodeWhenNotExists() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -254,7 +274,8 @@ class PageTest {
 
     @Test
     void getParam() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -282,7 +303,8 @@ class PageTest {
 
     @Test
     void isEmpty() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -303,7 +325,8 @@ class PageTest {
 
     @Test
     void setCanonicalLink() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -335,7 +358,8 @@ class PageTest {
 
     @Test
     void setResponseContentType() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));
@@ -367,7 +391,8 @@ class PageTest {
 
     @Test
     void setResponseContentTypeWhenHTTPMethoIsHead() {
-        try (MockedStatic<RegistryDB> ignored = mockStatic(RegistryDB.class)) {
+        try (MockedStatic<RegistryDB> registry = mockStatic(RegistryDB.class)) {
+            mockCollectionForEstimatedCount(registry);
             ClientSession mongoSession = mock(ClientSession.class);
             RoutingContext context = mock(RoutingContext.class);
             when(context.response()).thenReturn(mock(HttpServerResponse.class));

--- a/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
@@ -605,10 +605,11 @@ class RegistryDBTest {
         String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
         assertTrue(RegistryDB.has(session, Collection.NANOPUBS.toString(), ac));
 
-        // Verify counter was assigned
+        // Verify seqNum was assigned (and counter for transition compatibility)
         Document doc = RegistryDB.collection(Collection.NANOPUBS.toString()).find(session, new Document("_id", ac)).first();
         assertNotNull(doc);
-        assertTrue(doc.getLong("counter") > 0);
+        assertTrue(doc.getLong("seqNum") > 0);
+        assertEquals(doc.getLong("seqNum"), doc.getLong("counter")); // TODO(transition): remove counter check
         assertEquals(Utils.getHash(pubkey), doc.getString("pubkey"));
     }
 
@@ -694,6 +695,170 @@ class RegistryDBTest {
                 new Document("pubkey", pubkeyHash).append("type", NanopubLoader.INTRO_TYPE_HASH)).first();
         assertNotNull(listDoc);
         assertEquals(EntryStatus.encountered.getValue(), listDoc.getString("status"));
+    }
+
+    // --- seqNum tests (write-first, expect to fail until implementation) ---
+
+    @Test
+    void loadNanopubVerifiedStoresSeqNum() throws MalformedNanopubException, IOException {
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        File file = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+        Nanopub nanopub = new NanopubImpl(file);
+        String pubkey = RegistryDB.getPubkey(nanopub);
+
+        assertTrue(RegistryDB.loadNanopubVerified(session, nanopub, pubkey, null));
+
+        String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
+        Document doc = RegistryDB.collection(Collection.NANOPUBS.toString()).find(session, new Document("_id", ac)).first();
+        assertNotNull(doc);
+        assertTrue(doc.getLong("seqNum") > 0, "seqNum should be assigned and > 0");
+        // TODO(transition): verify counter field is also written with same value
+        assertEquals(doc.getLong("seqNum"), doc.getLong("counter"), "counter should match seqNum during transition");
+    }
+
+    @Test
+    void loadMultipleNanopubsAssignsUniqueSeqNums() throws MalformedNanopubException, IOException {
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        File file1 = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+        File file2 = NanopubTestSuite.getLatest().getByArtifactCode("RAjPRftIBK8ZbR2LausQpdsMbI39_eRe07AZwfHTsm2dY").getFirst().toFile();
+        Nanopub np1 = new NanopubImpl(file1);
+        Nanopub np2 = new NanopubImpl(file2);
+
+        String pubkey1 = RegistryDB.getPubkey(np1);
+        String pubkey2 = RegistryDB.getPubkey(np2);
+        assertNotNull(pubkey1);
+        assertNotNull(pubkey2);
+        RegistryDB.loadNanopubVerified(session, np1, pubkey1, null);
+        RegistryDB.loadNanopubVerified(session, np2, pubkey2, null);
+
+        String ac1 = TrustyUriUtils.getArtifactCode(np1.getUri().stringValue());
+        String ac2 = TrustyUriUtils.getArtifactCode(np2.getUri().stringValue());
+        Document doc1 = RegistryDB.collection(Collection.NANOPUBS.toString()).find(session, new Document("_id", ac1)).first();
+        Document doc2 = RegistryDB.collection(Collection.NANOPUBS.toString()).find(session, new Document("_id", ac2)).first();
+        assertNotNull(doc1, "First nanopub should be stored");
+        assertNotNull(doc2, "Second nanopub should be stored");
+
+        long seq1 = doc1.getLong("seqNum");
+        long seq2 = doc2.getLong("seqNum");
+        assertNotEquals(seq1, seq2, "seqNums must be unique");
+        assertTrue(seq2 > seq1, "seqNums should be monotonically increasing");
+    }
+
+    @Test
+    void seqNumsHaveGapsAcrossThreads() throws Exception {
+        RegistryDB.init();
+        // Clear the main thread's ThreadLocal to ensure fresh batch allocation
+        java.lang.reflect.Field tlField = RegistryDB.class.getDeclaredField("seqNumRange");
+        tlField.setAccessible(true);
+        ((ThreadLocal<?>) tlField.get(null)).remove();
+
+        File file1 = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+        File file2 = NanopubTestSuite.getLatest().getByArtifactCode("RAjPRftIBK8ZbR2LausQpdsMbI39_eRe07AZwfHTsm2dY").getFirst().toFile();
+        Nanopub np1 = new NanopubImpl(file1);
+        Nanopub np2 = new NanopubImpl(file2);
+        String pubkey1 = RegistryDB.getPubkey(np1);
+        String pubkey2 = RegistryDB.getPubkey(np2);
+
+        // Load one nanopub on the main thread (claims first batch, uses slot 1)
+        try (ClientSession session = RegistryDB.getClient().startSession()) {
+            RegistryDB.loadNanopubVerified(session, np1, pubkey1, null);
+        }
+
+        // Load another nanopub on a different thread (should claim a new batch)
+        long[] otherSeqNum = new long[1];
+        Thread t = new Thread(() -> {
+            try (ClientSession session = RegistryDB.getClient().startSession()) {
+                RegistryDB.loadNanopubVerified(session, np2, pubkey2, null);
+                String ac = TrustyUriUtils.getArtifactCode(np2.getUri().stringValue());
+                Document doc = RegistryDB.collection(Collection.NANOPUBS.toString()).find(session, new Document("_id", ac)).first();
+                otherSeqNum[0] = doc.getLong("seqNum");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        t.start();
+        t.join();
+
+        // With default batch size 20: main thread gets batch [1,20], other thread gets [21,40]
+        try (ClientSession session = RegistryDB.getClient().startSession()) {
+            String ac1 = TrustyUriUtils.getArtifactCode(np1.getUri().stringValue());
+            Document doc1 = RegistryDB.collection(Collection.NANOPUBS.toString()).find(session, new Document("_id", ac1)).first();
+            long seq1 = doc1.getLong("seqNum");
+
+            assertTrue(otherSeqNum[0] > seq1 + 1, "seqNums from different threads should have gaps (batch allocation)");
+        }
+    }
+
+    @Test
+    void initSeqNumCounterRecoversFromExistingData() throws MalformedNanopubException, IOException, NoSuchFieldException, IllegalAccessException {
+        // First init and load to establish seqNum=50 in the DB
+        RegistryDB.init();
+        try (ClientSession session = RegistryDB.getClient().startSession()) {
+            // Insert a document directly with a high seqNum to simulate existing data
+            RegistryDB.collection(Collection.NANOPUBS.toString()).insertOne(session,
+                    new Document("_id", "RAfakeArtifactCode00000000000000000000000000000")
+                            .append("fullId", "http://example.org/fake")
+                            .append("seqNum", 50L)
+                            .append("counter", 50L)
+                            .append("pubkey", "fakepubkeyhash"));
+        }
+
+        // Re-init (simulates restart) — should recover from max(seqNum)
+        TestUtils.clearStaticFields(RegistryDB.class, "mongoClient", "mongoDB");
+        // Clear ThreadLocal to force new batch allocation after re-init
+        java.lang.reflect.Field tlField = RegistryDB.class.getDeclaredField("seqNumRange");
+        tlField.setAccessible(true);
+        ((ThreadLocal<?>) tlField.get(null)).remove();
+        RegistryDB.init();
+
+        // Load a real nanopub — its seqNum should be > 50
+        try (ClientSession session = RegistryDB.getClient().startSession()) {
+            File file = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+            Nanopub nanopub = new NanopubImpl(file);
+            String pubkey = RegistryDB.getPubkey(nanopub);
+            RegistryDB.loadNanopubVerified(session, nanopub, pubkey, null);
+
+            String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
+            Document doc = RegistryDB.collection(Collection.NANOPUBS.toString()).find(session, new Document("_id", ac)).first();
+            assertTrue(doc.getLong("seqNum") > 50, "seqNum should be > 50 after recovery from existing data");
+        }
+    }
+
+    @Test
+    void initSeqNumCounterRecoversFromLegacyCounterField() throws MalformedNanopubException, IOException, NoSuchFieldException, IllegalAccessException {
+        // Simulate a legacy database that only has "counter" field (no "seqNum")
+        RegistryDB.init();
+        try (ClientSession session = RegistryDB.getClient().startSession()) {
+            RegistryDB.collection(Collection.NANOPUBS.toString()).insertOne(session,
+                    new Document("_id", "RAfakeLegacyArtifactCode0000000000000000000000")
+                            .append("fullId", "http://example.org/legacy")
+                            .append("counter", 100L)
+                            .append("pubkey", "fakepubkeyhash"));
+            // Note: no "seqNum" field — this is a legacy document
+        }
+
+        // Re-init — should recover from max(counter) since seqNum is absent
+        TestUtils.clearStaticFields(RegistryDB.class, "mongoClient", "mongoDB");
+        // Clear ThreadLocal to force new batch allocation after re-init
+        java.lang.reflect.Field tlField = RegistryDB.class.getDeclaredField("seqNumRange");
+        tlField.setAccessible(true);
+        ((ThreadLocal<?>) tlField.get(null)).remove();
+        RegistryDB.init();
+
+        try (ClientSession session = RegistryDB.getClient().startSession()) {
+            File file = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+            Nanopub nanopub = new NanopubImpl(file);
+            String pubkey = RegistryDB.getPubkey(nanopub);
+            RegistryDB.loadNanopubVerified(session, nanopub, pubkey, null);
+
+            String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
+            Document doc = RegistryDB.collection(Collection.NANOPUBS.toString()).find(session, new Document("_id", ac)).first();
+            assertTrue(doc.getLong("seqNum") > 100, "seqNum should be > 100 after recovery from legacy counter field");
+        }
     }
 
 }

--- a/src/test/java/com/knowledgepixels/registry/RegistryInfoTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryInfoTest.java
@@ -33,7 +33,7 @@ class RegistryInfoTest {
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "trustStateCounter")).thenReturn(TRUST_STATE_COUNTER);
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "lastTrustStateUpdate")).thenReturn(LAST_TRUST_STATE_UPDATE);
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "trustStateHash")).thenReturn(TRUST_STATE_HASH);
-            registry.when(() -> RegistryDB.getMaxValue(mockSession, Collection.NANOPUBS.toString(), "counter")).thenReturn(LOAD_COUNTER);
+            registry.when(() -> RegistryDB.getMaxValue(mockSession, Collection.NANOPUBS.toString(), "seqNum")).thenReturn(LOAD_COUNTER);
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "status")).thenReturn(STATUS);
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "coverageTypes")).thenReturn(COVERAGE_TYPES);
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "coverageAgents")).thenReturn(COVERAGE_AGENTS);
@@ -68,6 +68,7 @@ class RegistryInfoTest {
                                   + "\"agentCount\":" + AGENT_COUNT + ","
                                   + "\"accountCount\":" + ACCOUNT_COUNT + ","
                                   + "\"nanopubCount\":" + NANOPUB_COUNT + ","
+                                  + "\"seqNum\":" + LOAD_COUNTER + ","
                                   + "\"loadCounter\":" + LOAD_COUNTER + ","
                                   + "\"isTestInstance\":" + IS_TEST_INSTANCE
                                   + "}";
@@ -83,7 +84,7 @@ class RegistryInfoTest {
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "trustStateCounter")).thenReturn(TRUST_STATE_COUNTER);
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "lastTrustStateUpdate")).thenReturn(LAST_TRUST_STATE_UPDATE);
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "trustStateHash")).thenReturn(TRUST_STATE_HASH);
-            registry.when(() -> RegistryDB.getMaxValue(mockSession, Collection.NANOPUBS.toString(), "counter")).thenReturn(LOAD_COUNTER);
+            registry.when(() -> RegistryDB.getMaxValue(mockSession, Collection.NANOPUBS.toString(), "seqNum")).thenReturn(LOAD_COUNTER);
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "status")).thenReturn(STATUS);
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "coverageTypes")).thenReturn(COVERAGE_TYPES);
             registry.when(() -> RegistryDB.getValue(mockSession, Collection.SERVER_INFO.toString(), "coverageAgents")).thenReturn(COVERAGE_AGENTS);
@@ -118,6 +119,7 @@ class RegistryInfoTest {
                                   + "\"agentCount\":" + AGENT_COUNT + ","
                                   + "\"accountCount\":" + ACCOUNT_COUNT + ","
                                   + "\"nanopubCount\":" + NANOPUB_COUNT + ","
+                                  + "\"seqNum\":" + LOAD_COUNTER + ","
                                   + "\"loadCounter\":" + LOAD_COUNTER + ","
                                   + "\"isTestInstance\":" + IS_TEST_INSTANCE
                                   + "}";

--- a/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryPeerConnectorTest.java
@@ -126,6 +126,8 @@ class RegistryPeerConnectorTest {
             Document state = getPeerState(session, "https://peer.example.com/");
             assertNotNull(state);
             assertEquals(123L, state.getLong("setupId"));
+            assertEquals(42000L, state.getLong("seqNum"));
+            // TODO(transition): remove loadCounter assertion after all peers upgraded
             assertEquals(42000L, state.getLong("loadCounter"));
             assertNotNull(state.getLong("lastChecked"));
         }
@@ -136,6 +138,8 @@ class RegistryPeerConnectorTest {
             updatePeerState(session, "https://peer.example.com/", 123L, 200L);
 
             Document state = getPeerState(session, "https://peer.example.com/");
+            assertEquals(200L, state.getLong("seqNum"));
+            // TODO(transition): remove loadCounter assertion after all peers upgraded
             assertEquals(200L, state.getLong("loadCounter"));
             assertEquals(1, collection(Collection.PEER_STATE.toString()).countDocuments(session));
         }
@@ -150,13 +154,13 @@ class RegistryPeerConnectorTest {
         }
 
         @Test
-        void syncWithPeer_skipsWhenLoadCounterUnchanged() {
+        void syncWithPeer_skipsWhenSeqNumUnchanged() {
             updatePeerState(session, "https://peer.example.com/", 123L, 500L);
 
             syncWithPeer(session, "https://peer.example.com/", 123L, 500L);
 
             Document state = getPeerState(session, "https://peer.example.com/");
-            assertEquals(500L, state.getLong("loadCounter"));
+            assertEquals(500L, state.getLong("seqNum"));
         }
 
         @Test
@@ -255,8 +259,8 @@ class RegistryPeerConnectorTest {
 
             assertEquals(100L, state1.getLong("setupId"));
             assertEquals(200L, state2.getLong("setupId"));
-            assertEquals(500L, state1.getLong("loadCounter"));
-            assertEquals(600L, state2.getLong("loadCounter"));
+            assertEquals(500L, state1.getLong("seqNum"));
+            assertEquals(600L, state2.getLong("seqNum"));
         }
     }
 
@@ -266,6 +270,109 @@ class RegistryPeerConnectorTest {
         @Test
         void peerStateCollectionName() {
             assertEquals("peerState", Collection.PEER_STATE.toString());
+        }
+    }
+
+    // --- seqNum tests (write-first, expect to fail until implementation) ---
+
+    @Nested
+    class HeaderSeqNumTests {
+
+        private HttpResponse makeResponse(String... headers) {
+            HttpResponse resp = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200, "OK"));
+            for (int i = 0; i < headers.length; i += 2) {
+                resp.setHeader(headers[i], headers[i + 1]);
+            }
+            return resp;
+        }
+
+        @Test
+        void getHeaderLong_readsSeqNumHeader() {
+            HttpResponse resp = makeResponse("Nanopub-Registry-SeqNum", "5000");
+            assertEquals(5000L, getHeaderLong(resp, "Nanopub-Registry-SeqNum"));
+        }
+
+        @Test
+        void getHeaderLong_readsNanopubCountHeader() {
+            HttpResponse resp = makeResponse("Nanopub-Registry-Nanopub-Count", "4900");
+            assertEquals(4900L, getHeaderLong(resp, "Nanopub-Registry-Nanopub-Count"));
+        }
+    }
+
+    @Nested
+    @Testcontainers
+    class PeerStateSeqNumTests {
+
+        private FakeEnv fakeEnv;
+        private ClientSession session;
+
+        @Container
+        private final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:7.0.0");
+
+        @BeforeEach
+        void setUp() throws Exception {
+            fakeEnv = TestUtils.setupFakeEnv();
+            TestUtils.setupDBEnv(mongoDBContainer, "nanopubRegistryTest");
+            TestUtils.clearStaticFields(RegistryDB.class, "mongoClient", "mongoDB");
+            RegistryDB.init();
+            session = RegistryDB.getClient().startSession();
+        }
+
+        @AfterEach
+        void tearDown() throws Exception {
+            if (session != null) session.close();
+            TestUtils.cleanupDataDir();
+            fakeEnv.reset();
+        }
+
+        @Test
+        void updatePeerState_storesSeqNum() {
+            updatePeerState(session, "https://peer.example.com/", 123L, 42000L);
+
+            Document state = getPeerState(session, "https://peer.example.com/");
+            assertNotNull(state);
+            assertEquals(42000L, state.getLong("seqNum"), "peerState should store seqNum field");
+        }
+
+        @Test
+        void syncWithPeer_readsLegacyLoadCounterFromPeerState() {
+            // Manually insert a legacy peerState doc with "loadCounter" but no "seqNum"
+            collection(Collection.PEER_STATE.toString()).insertOne(session,
+                    new Document("_id", "https://legacy-peer.example.com/")
+                            .append("setupId", 100L)
+                            .append("loadCounter", 300L)
+                            .append("lastChecked", System.currentTimeMillis()));
+
+            // syncWithPeer should read the legacy loadCounter as baseline
+            // and skip sync since seqNum matches (300 == 300)
+            syncWithPeer(session, "https://legacy-peer.example.com/", 100L, 300L);
+
+            // After sync, peerState should now have the seqNum field
+            Document state = getPeerState(session, "https://legacy-peer.example.com/");
+            assertNotNull(state);
+            assertEquals(300L, state.getLong("seqNum"), "peerState should be migrated to seqNum");
+        }
+
+        @Test
+        void syncWithPeer_skipsWhenSeqNumUnchanged() {
+            updatePeerState(session, "https://peer.example.com/", 123L, 500L);
+
+            syncWithPeer(session, "https://peer.example.com/", 123L, 500L);
+
+            Document state = getPeerState(session, "https://peer.example.com/");
+            assertEquals(500L, state.getLong("seqNum"), "seqNum should remain unchanged");
+        }
+
+        @Test
+        void multiplePeers_trackedIndependentlyWithSeqNum() {
+            updatePeerState(session, "https://peer1.example.com/", 100L, 500L);
+            updatePeerState(session, "https://peer2.example.com/", 200L, 600L);
+
+            Document state1 = getPeerState(session, "https://peer1.example.com/");
+            Document state2 = getPeerState(session, "https://peer2.example.com/");
+
+            assertEquals(500L, state1.getLong("seqNum"));
+            assertEquals(600L, state2.getLong("seqNum"));
         }
     }
 }

--- a/src/test/java/com/knowledgepixels/registry/db/IndexInitializerTest.java
+++ b/src/test/java/com/knowledgepixels/registry/db/IndexInitializerTest.java
@@ -43,7 +43,7 @@ class IndexInitializerTest {
     @Test
     void initCollections() {
         assertEquals(2, getNumberOfIndexes(Collection.TASKS.toString()));
-        assertEquals(4, getNumberOfIndexes(Collection.NANOPUBS.toString()));
+        assertEquals(5, getNumberOfIndexes(Collection.NANOPUBS.toString()));
         assertEquals(4, getNumberOfIndexes("lists"));
         assertEquals(6, getNumberOfIndexes("listEntries"));
         assertEquals(5, getNumberOfIndexes("invalidations"));


### PR DESCRIPTION
## Summary

- Replace per-nanopub `findOneAndUpdate($inc)` on the global counter with thread-local batch allocation (20 seqNums at a time), reducing MongoDB contention ~20x — the primary bottleneck for multi-generator throughput
- Rename `counter` field to `seqNum` since batch allocation introduces gaps (no longer a contiguous count)
- Add `Nanopub-Registry-Nanopub-Count` header exposing actual document count via `estimatedDocumentCount()`
- Fix pre-existing concurrent upsert race in `recordHash()`
- Full backwards compatibility with old peers during transition (dual fields, dual headers, dual query params)

## Motivation

Infrastructure benchmarks showed 9 generators achieving only 5.86 np/s total (0.65 np/s each) despite using different pubkeys — the shared global `getNextNanopubCounter()` was the serialization point. With batch allocation, each thread claims 20 sequence numbers in one MongoDB operation, then hands them out locally with zero contention.

## Backwards compatibility

All transition measures are marked with `TODO(transition)` comments:
- Nanopub documents written with both `seqNum` and `counter` fields
- Both `afterSeqNum` and `afterCounter` query params accepted
- Both `Nanopub-Registry-SeqNum` and `Nanopub-Registry-Load-Counter` headers sent
- peerState reads `seqNum` with `loadCounter` fallback
- Both `seqNum` and `counter` indexes maintained

## Test plan

- [x] 5 new RegistryDB tests (seqNum storage, uniqueness, batch gaps, init recovery, legacy recovery)
- [x] 6 new RegistryPeerConnector tests (header reading, peerState migration, legacy fallback)
- [x] Updated existing tests for new field names
- [x] All 149 tests pass
- [x] Verified locally against fresh DB syncing from public registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)