### PR TITLE
perf: batched single-writer queue for list entry inserts

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/ListEntryWriter.java
+++ b/src/main/java/com/knowledgepixels/registry/ListEntryWriter.java
@@ -1,0 +1,246 @@
+package com.knowledgepixels.registry;
+
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.model.InsertOneModel;
+import com.mongodb.client.model.WriteModel;
+import net.trustyuri.TrustyUriUtils;
+import org.bson.Document;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.knowledgepixels.registry.RegistryDB.*;
+
+/**
+ * Batched single-writer per list for listEntries. Multiple callers enqueue entries
+ * concurrently; a single writer per (pubkey, type) list drains the queue, computes
+ * the checksum chain in-memory, and does a bulk insert.
+ */
+public final class ListEntryWriter {
+
+    private static final Logger logger = LoggerFactory.getLogger(ListEntryWriter.class);
+
+    private static final int BATCH_SIZE = Integer.parseInt(
+            Utils.getEnv("REGISTRY_LIST_WRITER_BATCH_SIZE", "50"));
+    private static final int THREAD_COUNT = Integer.parseInt(
+            Utils.getEnv("REGISTRY_LIST_WRITER_THREADS", "4"));
+
+    private static final ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    private static final ConcurrentHashMap<String, ListQueue> queues = new ConcurrentHashMap<>();
+
+    private ListEntryWriter() {}
+
+    private static final class WriteRequest {
+        final Nanopub nanopub;
+        final String ac;
+        final CompletableFuture<Void> result = new CompletableFuture<>();
+
+        WriteRequest(Nanopub nanopub, String ac) {
+            this.nanopub = nanopub;
+            this.ac = ac;
+        }
+    }
+
+    private static final class ListQueue {
+        final String pubkeyHash;
+        final String typeHash;
+        final LinkedBlockingQueue<WriteRequest> queue = new LinkedBlockingQueue<>();
+        final AtomicBoolean processing = new AtomicBoolean(false);
+
+        ListQueue(String pubkeyHash, String typeHash) {
+            this.pubkeyHash = pubkeyHash;
+            this.typeHash = typeHash;
+        }
+    }
+
+    /**
+     * Enqueue a nanopub to be added to the specified list. Blocks until the entry
+     * is written or throws if the write fails.
+     */
+    static void enqueue(String pubkeyHash, String typeHash, Nanopub nanopub, String ac) {
+        String key = pubkeyHash + ":" + typeHash;
+        ListQueue listQueue = queues.computeIfAbsent(key, k -> new ListQueue(pubkeyHash, typeHash));
+
+        WriteRequest request = new WriteRequest(nanopub, ac);
+        listQueue.queue.add(request);
+        tryScheduleDrain(key, listQueue);
+
+        try {
+            request.result.get();
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException re) throw re;
+            throw new RuntimeException("List entry write failed", cause);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for list entry write", e);
+        }
+    }
+
+    private static void tryScheduleDrain(String key, ListQueue listQueue) {
+        if (listQueue.processing.compareAndSet(false, true)) {
+            executor.submit(() -> drain(key, listQueue));
+        }
+    }
+
+    private static void drain(String key, ListQueue listQueue) {
+        try {
+            List<WriteRequest> batch = new ArrayList<>(BATCH_SIZE);
+            listQueue.queue.drainTo(batch, BATCH_SIZE);
+            if (batch.isEmpty()) {
+                return;
+            }
+
+            processBatch(listQueue, batch);
+        } catch (Exception e) {
+            logger.error("Unexpected error in list writer drain for {}", key, e);
+        } finally {
+            listQueue.processing.set(false);
+            // Re-schedule if more entries arrived while we were processing
+            if (!listQueue.queue.isEmpty()) {
+                tryScheduleDrain(key, listQueue);
+            }
+        }
+    }
+
+    private static void processBatch(ListQueue listQueue, List<WriteRequest> batch) {
+        try (ClientSession session = getClient().startSession()) {
+            String pubkeyHash = listQueue.pubkeyHash;
+            String typeHash = listQueue.typeHash;
+
+            // Initialize maxPosition for legacy lists (one-time migration)
+            initListPositionIfNeeded(session, pubkeyHash, typeHash);
+
+            // Filter out entries already in the list and deduplicate within batch
+            LinkedHashSet<String> seenAcs = new LinkedHashSet<>();
+            List<WriteRequest> toInsert = new ArrayList<>(batch.size());
+            for (WriteRequest req : batch) {
+                if (!seenAcs.add(req.ac)) {
+                    // Duplicate within this batch — complete as success
+                    req.result.complete(null);
+                    continue;
+                }
+                if (has(session, "listEntries",
+                        new Document("pubkey", pubkeyHash).append("type", typeHash).append("np", req.ac))) {
+                    req.result.complete(null);
+                    continue;
+                }
+                toInsert.add(req);
+            }
+
+            if (toInsert.isEmpty()) return;
+
+            // Read current maxPosition and the checksum at that position
+            Document listDoc = collection("lists").find(session,
+                    new Document("pubkey", pubkeyHash).append("type", typeHash)).first();
+            long maxPosition = (listDoc != null && listDoc.get("maxPosition") != null)
+                    ? listDoc.getLong("maxPosition") : -1L;
+
+            String prevChecksum;
+            if (maxPosition < 0) {
+                prevChecksum = NanopubUtils.INIT_CHECKSUM;
+            } else {
+                Document prevEntry = collection("listEntries").find(session,
+                        new Document("pubkey", pubkeyHash).append("type", typeHash)
+                                .append("position", maxPosition)).first();
+                prevChecksum = (prevEntry != null) ? prevEntry.getString("checksum") : NanopubUtils.INIT_CHECKSUM;
+            }
+
+            // Build all insert documents with sequential positions and chained checksums
+            List<WriteModel<Document>> writes = new ArrayList<>(toInsert.size());
+            long nextPosition = maxPosition + 1;
+            String checksum = prevChecksum;
+
+            for (int i = 0; i < toInsert.size(); i++) {
+                WriteRequest req = toInsert.get(i);
+                checksum = NanopubUtils.updateXorChecksum(req.nanopub.getUri(), checksum);
+
+                writes.add(new InsertOneModel<>(new Document("pubkey", pubkeyHash)
+                        .append("type", typeHash)
+                        .append("position", nextPosition + i)
+                        .append("np", req.ac)
+                        .append("checksum", checksum)
+                        .append("invalidated", false)));
+            }
+
+            // Bulk insert
+            try {
+                collection("listEntries").bulkWrite(session, writes);
+            } catch (MongoBulkWriteException e) {
+                // Some entries may have been inserted by a concurrent path (e.g. POST handler
+                // duplicate check raced). Fail the whole batch and let callers retry.
+                for (WriteRequest req : toInsert) {
+                    req.result.completeExceptionally(e);
+                }
+                return;
+            }
+
+            // Update maxPosition to the final position
+            long finalPosition = nextPosition + toInsert.size() - 1;
+            collection("lists").updateOne(session,
+                    new Document("pubkey", pubkeyHash).append("type", typeHash),
+                    new Document("$set", new Document("maxPosition", finalPosition)));
+
+            // Complete all futures
+            for (WriteRequest req : toInsert) {
+                req.result.complete(null);
+            }
+
+            logger.debug("Batch inserted {} entries for list {}:{} (positions {}-{})",
+                    toInsert.size(), pubkeyHash, typeHash, nextPosition, finalPosition);
+
+        } catch (Exception e) {
+            // Complete all pending futures with the error
+            for (WriteRequest req : batch) {
+                if (!req.result.isDone()) {
+                    req.result.completeExceptionally(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Lazily initializes the maxPosition field on a lists document for lists
+     * created before this field existed.
+     */
+    private static void initListPositionIfNeeded(ClientSession mongoSession, String pubkeyHash, String typeHash) {
+        Document listDoc = collection("lists").find(mongoSession,
+                new Document("pubkey", pubkeyHash).append("type", typeHash)).first();
+        if (listDoc == null || listDoc.get("maxPosition") != null) return;
+
+        Document maxDoc = getMaxValueDocument(mongoSession, "listEntries",
+                new Document("pubkey", pubkeyHash).append("type", typeHash), "position");
+        long maxPos = (maxDoc != null) ? maxDoc.getLong("position") : -1L;
+
+        collection("lists").updateOne(mongoSession,
+                new Document("pubkey", pubkeyHash).append("type", typeHash)
+                        .append("maxPosition", new Document("$exists", false)),
+                new Document("$set", new Document("maxPosition", maxPos)));
+    }
+
+    /**
+     * Gracefully shuts down the writer, draining any remaining queues.
+     */
+    public static void shutdown() {
+        logger.info("Shutting down ListEntryWriter...");
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                logger.warn("ListEntryWriter did not terminate in 30s, forcing shutdown");
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            executor.shutdownNow();
+        }
+        logger.info("ListEntryWriter shutdown complete");
+    }
+}

--- a/src/main/java/com/knowledgepixels/registry/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/registry/MainVerticle.java
@@ -125,6 +125,7 @@ public class MainVerticle extends AbstractVerticle {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {
                 logger.info("Gracefully shutting down...");
+                ListEntryWriter.shutdown();
                 RegistryDB.getClient().close();
                 vertx.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
                 logger.info("Graceful shutdown completed");

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -525,72 +525,8 @@ public class RegistryDB {
         if (has(mongoSession, "listEntries", new Document("pubkey", pubkeyHash).append("type", typeHash).append("np", ac))) {
             logger.debug("Already listed: {}", nanopub.getUri());
         } else {
-            initListPositionIfNeeded(mongoSession, pubkeyHash, typeHash);
-
-            for (int attempt = 0; ; attempt++) {
-                // Atomically claim next position
-                Document updated = collection("lists").findOneAndUpdate(mongoSession,
-                        new Document("pubkey", pubkeyHash).append("type", typeHash),
-                        new Document("$inc", new Document("maxPosition", 1L)),
-                        new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER));
-                long position = updated.getLong("maxPosition");
-
-                // Get checksum from previous entry by exact position lookup (O(1) index hit)
-                String checksum;
-                if (position == 0) {
-                    checksum = NanopubUtils.updateXorChecksum(nanopub.getUri(), NanopubUtils.INIT_CHECKSUM);
-                } else {
-                    Document prevEntry = collection("listEntries").find(mongoSession,
-                            new Document("pubkey", pubkeyHash).append("type", typeHash)
-                                    .append("position", position - 1)).first();
-                    String prevChecksum = (prevEntry != null) ? prevEntry.getString("checksum") : null;
-                    if (prevChecksum == null) {
-                        // Rare: previous entry not yet inserted by concurrent thread; fall back to sorted query
-                        Document maxDoc = getMaxValueDocument(mongoSession, "listEntries",
-                                new Document("pubkey", pubkeyHash).append("type", typeHash), "position");
-                        prevChecksum = (maxDoc != null) ? maxDoc.getString("checksum") : NanopubUtils.INIT_CHECKSUM;
-                    }
-                    checksum = NanopubUtils.updateXorChecksum(nanopub.getUri(), prevChecksum);
-                }
-
-                try {
-                    collection("listEntries").insertOne(mongoSession, new Document("pubkey", pubkeyHash)
-                            .append("type", typeHash).append("position", position).append("np", ac)
-                            .append("checksum", checksum).append("invalidated", false));
-                    break;
-                } catch (MongoWriteException e) {
-                    if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
-                    if (has(mongoSession, "listEntries", new Document("pubkey", pubkeyHash)
-                            .append("type", typeHash).append("np", ac))) {
-                        break; // Already listed by concurrent thread
-                    }
-                    if (attempt >= 100) {
-                        throw new RuntimeException("Failed to insert list entry after " + (attempt + 1) + " attempts");
-                    }
-                }
-            }
+            ListEntryWriter.enqueue(pubkeyHash, typeHash, nanopub, ac);
         }
-    }
-
-    /**
-     * Lazily initializes the maxPosition field on a lists document for lists
-     * created before this field existed. Uses a one-time sorted query, then
-     * all subsequent calls use the atomic counter.
-     */
-    private static void initListPositionIfNeeded(ClientSession mongoSession, String pubkeyHash, String typeHash) {
-        Document listDoc = collection("lists").find(mongoSession,
-                new Document("pubkey", pubkeyHash).append("type", typeHash)).first();
-        if (listDoc == null || listDoc.get("maxPosition") != null) return;
-
-        Document maxDoc = getMaxValueDocument(mongoSession, "listEntries",
-                new Document("pubkey", pubkeyHash).append("type", typeHash), "position");
-        long maxPos = (maxDoc != null) ? maxDoc.getLong("position") : -1L;
-
-        // Conditional update: only set if maxPosition still doesn't exist (race-safe)
-        collection("lists").updateOne(mongoSession,
-                new Document("pubkey", pubkeyHash).append("type", typeHash)
-                        .append("maxPosition", new Document("$exists", false)),
-                new Document("$set", new Document("maxPosition", maxPos)));
     }
 
     /**


### PR DESCRIPTION
## Summary

- Replace the contention-heavy retry loop in `addToList()` with a per-list single-writer queue (`ListEntryWriter`)
- Multiple concurrent callers for the same `(pubkey, type)` list are batched together: checksums are computed in-memory and entries are bulk-inserted via `bulkWrite()`
- Eliminates position races, fallback sorted queries, and duplicate key retries during parallel peer sync loading (LOAD_FULL, RUN_OPTIONAL_LOAD)
- Adds graceful shutdown support for draining remaining queues

## Motivation

During peer sync, `loadStreamInParallel` sends many nanopubs for the same pubkey through concurrent worker threads. The old `addToList()` retry loop caused workers to fight over the position counter, waste positions on failed inserts, and fall back to expensive sorted queries — all for the same list.

The single-writer queue serializes writes per list (correctness requirement for the checksum chain) while eliminating all contention overhead and enabling bulk inserts.

## Files changed

- **New:** `ListEntryWriter.java` — per-list write queue with batched drain logic
- **Modified:** `RegistryDB.java` — `addToList()` delegates to `ListEntryWriter.enqueue()`
- **Modified:** `MainVerticle.java` — shutdown hook drains queues before closing MongoDB

## Test plan

- [x] All 138 existing tests pass
- [x] Verified peer sync loading still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)