### PR TITLE
fix: retain only 10% of trust ratio when expanding trust paths

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -312,7 +312,9 @@ public enum Task implements Serializable {
                         double newRatio = (trustPath.getDouble("ratio") * 0.9) / pubkeySets.size() / pubkeySets.get(pd.getString("agent")).size();
                         insert(s, "trustPaths_loading", pd.append("ratio", newRatio));
                     }
-                    set(s, "trustPaths_loading", trustPath.append("type", "primary"));
+                    // Retain only 10% of the ratio — the other 90% was distributed to children
+                    double retainedRatio = trustPath.getDouble("ratio") * 0.1;
+                    set(s, "trustPaths_loading", trustPath.append("type", "primary").append("ratio", retainedRatio));
                     set(s, "accounts_loading", d.append("status", expanded.getValue()));
                 }
                 schedule(s, EXPAND_TRUST_PATHS.with("depth", depth));


### PR DESCRIPTION
## Summary

Fix trust ratio inflation in `EXPAND_TRUST_PATHS`: when an agent's path is expanded, 90% of its ratio is distributed to endorsees, but the parent previously kept its full ratio. Now the parent retains only 10%.

## The bug

In `EXPAND_TRUST_PATHS` (Task.java:312-315), when agent A with ratio R is expanded:
- Children get `R * 0.9 / numEndorsees` each (correct)
- A's path was converted from "extended" to "primary" but **kept ratio R** (bug)
- Should keep only `R * 0.1`

This caused the sum of all trust ratios to exceed 1.0. On the public registry: **1.03** instead of ≤ 1.0. With a larger, more interconnected network, the overshoot would grow.

## The fix

One line: reduce the parent's ratio to 10% when converting from "extended" to "primary":
```java
double retainedRatio = trustPath.getDouble("ratio") * 0.1;
set(s, "trustPaths_loading", trustPath.append("type", "primary").append("ratio", retainedRatio));
```

## Impact on quotas

With the fix, the 4 accounts currently exceeding their quotas will get lower quotas (ratios decrease). The trust network becomes properly bounded, which is a prerequisite for enforcing quotas.

## Test plan

- [x] All existing tests pass
- [ ] Deploy to test instance, verify sum of ratios ≤ 1.0
- [ ] Verify quota values are recalculated correctly after trust state update

🤖 Generated with [Claude Code](https://claude.com/claude-code)