### PR TITLE
fix: store and backfill nanopubs from encountered pubkeys

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -99,14 +99,20 @@ public class NanopubLoader {
             RegistryDB.loadNanopubVerified(mongoSession, np, verifiedPubkey, pubkeyHash, "$");
         } else if (has(mongoSession, "lists", new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH).append("status", "loaded"))) {
             RegistryDB.loadNanopubVerified(mongoSession, np, verifiedPubkey, pubkeyHash, INTRO_TYPE, ENDORSE_TYPE);
-        } else if (!has(mongoSession, "lists", new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH))) {
-            // Unknown pubkey: create encountered intro list so RUN_OPTIONAL_LOAD picks it up
-            try {
-                insert(mongoSession, "lists", new Document("pubkey", pubkeyHash)
-                        .append("type", INTRO_TYPE_HASH)
-                        .append("status", EntryStatus.encountered.getValue()));
-            } catch (MongoWriteException e) {
-                if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
+        } else {
+            // Pubkey not yet loaded (unknown or in transitional "encountered" state): store the
+            // nanopub in the nanopubs collection so it is not lost. RUN_OPTIONAL_LOAD will add it
+            // to the appropriate lists once the pubkey's intro/endorse have been fetched.
+            RegistryDB.loadNanopubVerified(mongoSession, np, verifiedPubkey, null);
+            if (!has(mongoSession, "lists", new Document("pubkey", pubkeyHash).append("type", INTRO_TYPE_HASH))) {
+                // Unknown pubkey: create encountered intro list so RUN_OPTIONAL_LOAD picks it up
+                try {
+                    insert(mongoSession, "lists", new Document("pubkey", pubkeyHash)
+                            .append("type", INTRO_TYPE_HASH)
+                            .append("status", EntryStatus.encountered.getValue()));
+                } catch (MongoWriteException e) {
+                    if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) throw e;
+                }
             }
         }
     }

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -898,6 +898,27 @@ public enum Task implements Serializable {
                 }
 
                 set(s, "lists", df.append("status", loaded.getValue()));
+
+                // Backfill nanopubs stored locally during the transitional period (i.e. before
+                // the $ list was loaded). Such nanopubs were stored in the nanopubs collection by
+                // simpleLoad() but never added to listEntries; add them to the $ list now.
+                log.info("Backfilling locally stored nanopubs for pubkey: {}", pubkeyHash);
+                try (MongoCursor<Document> npCursor = collection(Collection.NANOPUBS.toString())
+                        .find(s, new Document("pubkey", pubkeyHash)).cursor()) {
+                    while (npCursor.hasNext()) {
+                        String fullId = npCursor.next().getString("fullId");
+                        if (fullId == null) continue;
+                        try (ClientSession ws = RegistryDB.getClient().startSession()) {
+                            Nanopub np = NanopubLoader.retrieveLocalNanopub(ws, fullId);
+                            if (np != null && CoverageFilter.isCovered(np)) {
+                                loadNanopub(ws, np, pubkeyHash, "$");
+                                totalLoaded.incrementAndGet();
+                            }
+                        } catch (Exception ex) {
+                            log.info("Error backfilling nanopub {}: {}", fullId, ex.getMessage());
+                        }
+                    }
+                }
             }
 
             if (totalLoaded.get() > 0) {


### PR DESCRIPTION
Fixes #100

## Problem

When a nanopub arrives via peer sync for a pubkey in the `encountered` (transitional) state, `simpleLoad()` fell through all three `if/else if` branches and silently dropped the nanopub. The peer counter then advanced past that position, making the nanopub permanently unreachable on future syncs.

## Fix

Two-part fix:

**1. `NanopubLoader.simpleLoad()`** — add an `else` catch-all so nanopubs from unloaded pubkeys (unknown or encountered) are always stored in the `nanopubs` collection via `loadNanopubVerified(..., null)`. The `null` pubkeyHash stores the nanopub without adding it to `listEntries`; the encountered intro entry is still created so `RUN_OPTIONAL_LOAD` picks up the pubkey.

**2. `Task.RUN_OPTIONAL_LOAD` phase 2** — after marking a pubkey's `$` list as loaded, scan the local `nanopubs` collection for all nanopubs from that pubkey and backfill them into `listEntries` via `loadNanopub(ws, np, pubkeyHash, "$")`. `addToList()` is idempotent, so nanopubs already fetched from peers during phase 2 are safely skipped.

## Test plan

- [ ] Verify that a nanopub POSTed by a brand-new pubkey (unknown to the registry) is stored and later appears in the `$` list once `RUN_OPTIONAL_LOAD` processes that pubkey
- [ ] Verify that subsequent nanopubs arriving during the `encountered` window (before optional load completes) are not dropped
- [ ] Verify the backfill log line appears after phase 2 completes for a newly discovered pubkey

🤖 Generated with [Claude Code](https://claude.com/claude-code)