### PR TITLE
feat: hash-keyed trust state snapshots (#107)

### DIFF
--- a/design.md
+++ b/design.md
@@ -257,3 +257,34 @@ including those with their own primary paths, as long as they are not already pa
 
 These extended paths can themselves not be further extended.
 Therefore, each account can only append its endorsements to the location in its primary path.
+
+
+## Trust State Snapshots
+
+Downstream consumers (e.g. Nanopub Query) mirror the registry's trust state as immutable snapshots keyed by `trustStateHash`.
+To let them load a given trust state atomically and side-by-side with earlier states, the registry persists a structured snapshot each time the hash transitions.
+
+Snapshot writes happen inside `RELEASE_DATA` alongside the renames of the `_loading` collections.
+For each hash transition, a single document is upserted into the `trustStateSnapshots` collection:
+
+    trustStateSnapshots:
+      { _id:'<trustStateHash>', trustStateCounter:42, createdAt:'2026-04-15T...',
+        accounts: [ { pubkey, agent, status, depth, pathCount, ratio, quota }, ... ] }
+
+The `accounts` array omits the `$` sentinel and projects only fields that are outputs of the trust computation (volatile fields like the per-pubkey nanopub `count` are excluded).
+Retention is capped at the 100 most recent snapshots; older entries are pruned in the same task.
+
+Consumers read snapshots via:
+
+    GET /trust-state/<trustStateHash>.json
+
+which returns an envelope `{ trustStateHash, trustStateCounter, createdAt, accounts }` with `Cache-Control: public, immutable, max-age=31536000`.
+Returns `404` if the hash has been pruned or never existed.
+
+Change detection uses the existing `Nanopub-Registry-Trust-State-Hash` response header (set on every response).
+A typical consumer workflow:
+
+1. `HEAD /` → read `Nanopub-Registry-Trust-State-Hash`
+2. If the hash differs from the last seen, `GET /trust-state/<new_hash>.json` and load alongside the previous snapshot
+
+See also [TrustStatePage.java](src/main/java/com/knowledgepixels/registry/TrustStatePage.java) and the snapshot writer in [Task.java](src/main/java/com/knowledgepixels/registry/Task.java) (`RELEASE_DATA`).

--- a/src/main/java/com/knowledgepixels/registry/Collection.java
+++ b/src/main/java/com/knowledgepixels/registry/Collection.java
@@ -7,6 +7,7 @@ public enum Collection {
     AGENTS("agents"),
     ACCOUNTS("accounts"),
     NANOPUBS("nanopubs"),
+    TRUST_STATE_SNAPSHOTS("trustStateSnapshots"),
 
     TASKS("tasks"),
     PEER_STATE("peerState");

--- a/src/main/java/com/knowledgepixels/registry/ListPage.java
+++ b/src/main/java/com/knowledgepixels/registry/ListPage.java
@@ -153,7 +153,7 @@ public class ListPage extends Page {
             } else {
                 printHtmlHeader("Accounts for Pubkey " + getLabel(pubkey) + " - Nanopub Registry");
                 println("<h1>Accounts for Pubkey " + getLabel(pubkey) + "</h1>");
-                println("<p><a href=\"/list\">&lt; Account List</a></p>");
+                println("<p><a href=\"/list\">&lt; Current Trust State</a></p>");
                 println("<h3>Formats</h3>");
                 println("<p>");
                 println("<a href=\"/list/" + pubkey + ".json\">.json</a> |");
@@ -189,8 +189,8 @@ public class ListPage extends Page {
                     }
                     println("]");
                 } else {
-                    printHtmlHeader("Account List - Nanopub Registry");
-                    println("<h1>Account List</h1>");
+                    printHtmlHeader("Current Trust State - Nanopub Registry");
+                    println("<h1>Current Trust State</h1>");
                     println("<p><a href=\"/\">&lt; Home</a></p>");
                     println("<h3>Formats</h3>");
                     println("<p>");

--- a/src/main/java/com/knowledgepixels/registry/MainPage.java
+++ b/src/main/java/com/knowledgepixels/registry/MainPage.java
@@ -108,6 +108,10 @@ public class MainPage extends Page {
             println("<h3>Nanopubs</h3>");
             println("<p>Count: " + collection(Collection.NANOPUBS.toString()).estimatedDocumentCount() + "</p>");
             println("<p><a href=\"/nanopubs\">&gt; nanopubs</a></pi>");
+
+            println("<h3>Trust State Snapshots</h3>");
+            println("<p>Count: " + collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).countDocuments(mongoSession) + "</p>");
+            println("<p><a href=\"/trust-state\">&gt; trust state snapshots</a></p>");
             printHtmlFooter();
         }
     }

--- a/src/main/java/com/knowledgepixels/registry/MainPage.java
+++ b/src/main/java/com/knowledgepixels/registry/MainPage.java
@@ -97,21 +97,21 @@ public class MainPage extends Page {
                 }
             }
 
-            println("<h3>Accounts</h3>");
+            println("<h3>Current Trust State</h3>");
             if (status.equals("launching") || status.equals("coreLoading")) {
                 println("<p><em>(loading...)</em></p>");
             } else {
-                println("<p>Count: " + collection(Collection.ACCOUNTS.toString()).countDocuments(mongoSession) + "</p>");
-                println("<p><a href=\"/list\">&gt; accounts</a></pi>");
+                println("<p>Accounts: " + collection(Collection.ACCOUNTS.toString()).countDocuments(mongoSession) + "</p>");
+                println("<p><a href=\"/list\">&gt; current trust state</a></pi>");
             }
+
+            println("<h3>Trust State History</h3>");
+            println("<p>Retained snapshots: " + collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).countDocuments(mongoSession) + "</p>");
+            println("<p><a href=\"/trust-state\">&gt; trust state history</a></p>");
 
             println("<h3>Nanopubs</h3>");
             println("<p>Count: " + collection(Collection.NANOPUBS.toString()).estimatedDocumentCount() + "</p>");
             println("<p><a href=\"/nanopubs\">&gt; nanopubs</a></pi>");
-
-            println("<h3>Trust State Snapshots</h3>");
-            println("<p>Count: " + collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).countDocuments(mongoSession) + "</p>");
-            println("<p><a href=\"/trust-state\">&gt; trust state snapshots</a></p>");
             printHtmlFooter();
         }
     }

--- a/src/main/java/com/knowledgepixels/registry/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/registry/MainVerticle.java
@@ -47,6 +47,7 @@ public class MainVerticle extends AbstractVerticle {
         router.route(HttpMethod.GET, "/get/").handler(c -> c.response().putHeader("Location", "/").setStatusCode(307).end());
         router.route(HttpMethod.GET, "/get/*").handler(c -> NanopubPage.show(c, true));
         router.route(HttpMethod.GET, "/debug/*").handler(c -> DebugPage.show(c));
+        router.route(HttpMethod.GET, "/trust-state/*").handler(c -> TrustStatePage.show(c));
         router.route(HttpMethod.GET, "/style.css").handler(c -> ResourcePage.show(c, "style.css", "text/css"));
 
         // Metrics

--- a/src/main/java/com/knowledgepixels/registry/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/registry/MainVerticle.java
@@ -47,7 +47,7 @@ public class MainVerticle extends AbstractVerticle {
         router.route(HttpMethod.GET, "/get/").handler(c -> c.response().putHeader("Location", "/").setStatusCode(307).end());
         router.route(HttpMethod.GET, "/get/*").handler(c -> NanopubPage.show(c, true));
         router.route(HttpMethod.GET, "/debug/*").handler(c -> DebugPage.show(c));
-        router.route(HttpMethod.GET, "/trust-state/*").handler(c -> TrustStatePage.show(c));
+        router.route(HttpMethod.GET, "/trust-state*").handler(c -> TrustStatePage.show(c));
         router.route(HttpMethod.GET, "/style.css").handler(c -> ResourcePage.show(c, "style.css", "text/css"));
 
         // Metrics

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -5,6 +5,7 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.ReplaceOptions;
 import net.trustyuri.TrustyUriUtils;
 import org.apache.commons.lang.Validate;
 import org.bson.Document;
@@ -702,11 +703,38 @@ public enum Task implements Serializable {
             if (previousTrustStateHash == null || !previousTrustStateHash.equals(newTrustStateHash)) {
                 increaseStateCounter(s);
                 setValue(s, Collection.SERVER_INFO.toString(), "trustStateHash", newTrustStateHash);
+                Object trustStateCounter = getValue(s, Collection.SERVER_INFO.toString(), "trustStateCounter");
                 insert(s, "debug_trustPaths", new Document()
                         .append("trustStateTxt", DebugPage.getTrustPathsTxt(s))
                         .append("trustStateHash", newTrustStateHash)
-                        .append("trustStateCounter", getValue(s, Collection.SERVER_INFO.toString(), "trustStateCounter"))
+                        .append("trustStateCounter", trustStateCounter)
                 );
+
+                // Structured hash-keyed snapshot for consumer mirroring (#107).
+                // Reads the accounts collection just renamed from accounts_loading above (:697).
+                List<Document> snapshotAccounts = new ArrayList<>();
+                for (Document a : collection(Collection.ACCOUNTS.toString()).find(s)) {
+                    String pubkey = a.getString("pubkey");
+                    if ("$".equals(pubkey)) continue;
+                    snapshotAccounts.add(new Document()
+                            .append("pubkey", pubkey)
+                            .append("agent", a.getString("agent"))
+                            .append("status", a.getString("status"))
+                            .append("depth", a.get("depth"))
+                            .append("pathCount", a.get("pathCount"))
+                            .append("ratio", a.get("ratio"))
+                            .append("quota", a.get("quota")));
+                }
+                Document snapshot = new Document()
+                        .append("_id", newTrustStateHash)
+                        .append("trustStateCounter", trustStateCounter)
+                        .append("createdAt", ZonedDateTime.now().toString())
+                        .append("accounts", snapshotAccounts);
+                collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).replaceOne(
+                        s,
+                        new Document("_id", newTrustStateHash),
+                        snapshot,
+                        new ReplaceOptions().upsert(true));
             }
 
             if (status == coreLoading) {

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -688,6 +688,9 @@ public enum Task implements Serializable {
     },
 
     RELEASE_DATA {
+
+        private static final int TRUST_STATE_SNAPSHOT_RETENTION = 100;
+
         public void run(ClientSession s, Document taskDoc) {
             ServerStatus status = getServerStatus(s);
 
@@ -735,6 +738,24 @@ public enum Task implements Serializable {
                         new Document("_id", newTrustStateHash),
                         snapshot,
                         new ReplaceOptions().upsert(true));
+
+                // Prune beyond retention: collect _ids of snapshots past the Nth most recent, delete them.
+                // trustStateCounter is monotonically increasing (see increaseStateCounter above), so ordering is well-defined.
+                List<Object> toPrune = new ArrayList<>();
+                try (MongoCursor<Document> stale = collection(Collection.TRUST_STATE_SNAPSHOTS.toString())
+                        .find(s)
+                        .sort(descending("trustStateCounter"))
+                        .skip(TRUST_STATE_SNAPSHOT_RETENTION)
+                        .projection(new Document("_id", 1))
+                        .cursor()) {
+                    while (stale.hasNext()) {
+                        toPrune.add(stale.next().get("_id"));
+                    }
+                }
+                if (!toPrune.isEmpty()) {
+                    collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).deleteMany(
+                            s, new Document("_id", new Document("$in", toPrune)));
+                }
             }
 
             if (status == coreLoading) {

--- a/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
+++ b/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
@@ -98,15 +98,15 @@ public class TrustStatePage extends Page {
                 }
                 println("]");
             } else {
-                printHtmlHeader("Trust State Snapshots - Nanopub Registry");
-                println("<h1>Trust State Snapshots</h1>");
+                printHtmlHeader("Trust State History - Nanopub Registry");
+                println("<h1>Trust State History</h1>");
                 println("<p><a href=\"/\">&lt; Home</a></p>");
                 println("<h3>Formats</h3>");
                 println("<p>");
                 println("<a href=\"trust-state.json\">.json</a> |");
                 println("<a href=\"trust-state.json.txt\">.json.txt</a>");
                 println("</p>");
-                println("<h3>Retained Snapshots</h3>");
+                println("<h3>Past Trust States</h3>");
                 println("<ol>");
                 while (it.hasNext()) {
                     Document d = it.next();
@@ -148,8 +148,8 @@ public class TrustStatePage extends Page {
 
         // HTML detail view
         printHtmlHeader("Trust State " + getLabel(hash) + " - Nanopub Registry");
-        println("<h1>Trust State Snapshot</h1>");
-        println("<p><a href=\"/trust-state\">&lt; Snapshot List</a></p>");
+        println("<h1>Trust State <code>" + getLabel(hash) + "</code></h1>");
+        println("<p><a href=\"/trust-state\">&lt; Trust State History</a></p>");
         println("<h3>Formats</h3>");
         println("<p>");
         println("<a href=\"" + hash + ".json\">.json</a> |");

--- a/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
+++ b/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
@@ -1,21 +1,34 @@
 package com.knowledgepixels.registry;
 
 import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoCursor;
 import io.vertx.ext.web.RoutingContext;
 import org.bson.Document;
 
 import java.io.IOException;
+import java.util.List;
 
 import static com.knowledgepixels.registry.RegistryDB.collection;
+import static com.knowledgepixels.registry.Utils.*;
+import static com.mongodb.client.model.Projections.exclude;
+import static com.mongodb.client.model.Sorts.descending;
 
 /**
- * Serves hash-keyed trust state snapshots at <code>/trust-state/&lt;hash&gt;.json</code>.
+ * Serves hash-keyed trust state snapshots.
  *
- * <p>Content is immutable once a hash is known. Consumers use this endpoint after
- * detecting a hash change (via the {@code Nanopub-Registry-Trust-State-Hash} response
- * header) to load the corresponding snapshot side-by-side with the previous one.
+ * <ul>
+ *   <li><code>/trust-state</code> — list of retained snapshots (HTML or JSON)</li>
+ *   <li><code>/trust-state/&lt;hash&gt;</code> — single snapshot (HTML or JSON)</li>
+ * </ul>
+ *
+ * <p>Snapshot content is immutable once a hash is known. Consumers use
+ * <code>/trust-state/&lt;hash&gt;.json</code> after detecting a hash change (via the
+ * {@code Nanopub-Registry-Trust-State-Hash} response header) to load the corresponding
+ * snapshot side-by-side with the previous one.
  */
 public class TrustStatePage extends Page {
+
+    private static final String SUPPORTED_TYPES = TYPE_JSON + "," + TYPE_HTML;
 
     public static void show(RoutingContext context) {
         TrustStatePage page;
@@ -39,39 +52,151 @@ public class TrustStatePage extends Page {
         String req = getRequestString();
         String ext = getExtension();
 
-        // Only the .json extension is supported.
-        if (!"json".equals(ext)) {
+        String format;
+        if ("json".equals(ext)) {
+            format = TYPE_JSON;
+        } else if (ext == null || "html".equals(ext)) {
+            format = Utils.getMimeType(c, SUPPORTED_TYPES);
+        } else {
             c.response().setStatusCode(400).setStatusMessage("Invalid request: " + getFullRequest());
             return;
         }
 
-        // Path must be /trust-state/<hash>. The hash character set is intentionally
-        // permissive (404 on lookup miss is the authoritative check).
-        if (!req.matches("/trust-state/[A-Za-z0-9_\\-]+")) {
-            c.response().setStatusCode(400).setStatusMessage("Invalid request: " + getFullRequest());
-            return;
+        if (getPresentationFormat() != null) {
+            setRespContentType(getPresentationFormat());
+        } else {
+            setRespContentType(format);
         }
 
-        String hash = req.substring("/trust-state/".length());
+        if ("/trust-state".equals(req) || "/trust-state/".equals(req)) {
+            showList(format);
+        } else if (req.matches("/trust-state/[A-Za-z0-9_\\-]+")) {
+            String hash = req.substring("/trust-state/".length());
+            showDetail(hash, format);
+        } else {
+            c.response().setStatusCode(400).setStatusMessage("Invalid request: " + getFullRequest());
+        }
+    }
+
+    private void showList(String format) {
+        // Metadata only — the accounts array is heavy and not needed in the index.
+        try (MongoCursor<Document> it = collection(Collection.TRUST_STATE_SNAPSHOTS.toString())
+                .find(mongoSession)
+                .projection(exclude("accounts"))
+                .sort(descending("trustStateCounter"))
+                .cursor()) {
+            if (TYPE_JSON.equals(format)) {
+                println("[");
+                while (it.hasNext()) {
+                    Document d = it.next();
+                    Document out = new Document()
+                            .append("trustStateHash", d.getString("_id"))
+                            .append("trustStateCounter", d.get("trustStateCounter"))
+                            .append("createdAt", d.get("createdAt"));
+                    print(out.toJson());
+                    println(it.hasNext() ? "," : "");
+                }
+                println("]");
+            } else {
+                printHtmlHeader("Trust State Snapshots - Nanopub Registry");
+                println("<h1>Trust State Snapshots</h1>");
+                println("<p><a href=\"/\">&lt; Home</a></p>");
+                println("<h3>Formats</h3>");
+                println("<p>");
+                println("<a href=\"trust-state.json\">.json</a> |");
+                println("<a href=\"trust-state.json.txt\">.json.txt</a>");
+                println("</p>");
+                println("<h3>Retained Snapshots</h3>");
+                println("<ol>");
+                while (it.hasNext()) {
+                    Document d = it.next();
+                    String hash = d.getString("_id");
+                    println("<li>");
+                    println("<a href=\"/trust-state/" + hash + "\"><code>" + getLabel(hash) + "</code></a>");
+                    print(", counter " + d.get("trustStateCounter"));
+                    Object createdAt = d.get("createdAt");
+                    if (createdAt != null) {
+                        print(", " + createdAt.toString().replaceFirst("\\.[^.]*$", ""));
+                    }
+                    println("</li>");
+                }
+                println("</ol>");
+                printHtmlFooter();
+            }
+        }
+    }
+
+    private void showDetail(String hash, String format) {
         Document snapshot = collection(Collection.TRUST_STATE_SNAPSHOTS.toString())
                 .find(mongoSession, new Document("_id", hash)).first();
         if (snapshot == null) {
-            c.response().setStatusCode(404).setStatusMessage("Trust state snapshot not found");
+            getContext().response().setStatusCode(404).setStatusMessage("Trust state snapshot not found");
             return;
         }
 
-        setRespContentType("application/json");
-        // Content is immutable by construction: the URL encodes a hash that never rewrites.
-        c.response().putHeader("Cache-Control", "public, immutable, max-age=31536000");
+        if (TYPE_JSON.equals(format)) {
+            // Content is immutable by construction: the URL encodes a hash that never rewrites.
+            getContext().response().putHeader("Cache-Control", "public, immutable, max-age=31536000");
+            Document output = new Document()
+                    .append("trustStateHash", snapshot.getString("_id"))
+                    .append("trustStateCounter", snapshot.get("trustStateCounter"))
+                    .append("createdAt", snapshot.get("createdAt"))
+                    .append("accounts", snapshot.get("accounts"));
+            print(output.toJson());
+            return;
+        }
 
-        // Serialize as an envelope so consumers can verify the hash and sort by counter
-        // without reparsing the URL. _id (= hash) is renamed to trustStateHash in the output.
-        Document output = new Document()
-                .append("trustStateHash", snapshot.getString("_id"))
-                .append("trustStateCounter", snapshot.get("trustStateCounter"))
-                .append("createdAt", snapshot.get("createdAt"))
-                .append("accounts", snapshot.get("accounts"));
-        print(output.toJson());
+        // HTML detail view
+        printHtmlHeader("Trust State " + getLabel(hash) + " - Nanopub Registry");
+        println("<h1>Trust State Snapshot</h1>");
+        println("<p><a href=\"/trust-state\">&lt; Snapshot List</a></p>");
+        println("<h3>Formats</h3>");
+        println("<p>");
+        println("<a href=\"" + hash + ".json\">.json</a> |");
+        println("<a href=\"" + hash + ".json.txt\">.json.txt</a>");
+        println("</p>");
+        println("<h3>Hash</h3>");
+        println("<p><code>" + hash + "</code></p>");
+        println("<h3>Metadata</h3>");
+        println("<ul>");
+        println("<li><em>trustStateCounter:</em> " + snapshot.get("trustStateCounter") + "</li>");
+        Object createdAt = snapshot.get("createdAt");
+        if (createdAt != null) {
+            println("<li><em>createdAt:</em> " + createdAt.toString().replaceFirst("\\.[^.]*$", "") + "</li>");
+        }
+        Object accountsObj = snapshot.get("accounts");
+        int accountCount = (accountsObj instanceof List) ? ((List<?>) accountsObj).size() : 0;
+        println("<li><em>accountCount:</em> " + accountCount + "</li>");
+        println("</ul>");
+        println("<h3>Accounts</h3>");
+        println("<ol>");
+        if (accountsObj instanceof List) {
+            for (Object entry : (List<?>) accountsObj) {
+                if (!(entry instanceof Document)) continue;
+                Document a = (Document) entry;
+                String pubkey = a.getString("pubkey");
+                String agent = a.getString("agent");
+                println("<li>");
+                println("<a href=\"/list/" + pubkey + "\"><code>" + getLabel(pubkey) + "</code></a>");
+                if (agent != null && !agent.isBlank()) {
+                    print(" by <a href=\"/agent?id=" + Utils.urlEncode(agent) + "\">" + Utils.getAgentLabel(agent) + "</a>");
+                }
+                print(", status: " + a.get("status"));
+                print(", depth: " + a.get("depth"));
+                if (a.get("pathCount") != null) print(", pathCount: " + a.get("pathCount"));
+                if (a.get("ratio") != null) print(", ratio: " + a.get("ratio"));
+                if (a.get("quota") != null) print(", quota: " + a.get("quota"));
+                println("</li>");
+            }
+        }
+        println("</ol>");
+        printHtmlFooter();
+    }
+
+    private static String getLabel(String s) {
+        if (s == null) return null;
+        if (s.length() < 10) return s;
+        return s.substring(0, 10);
     }
 
 }

--- a/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
+++ b/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
@@ -1,0 +1,77 @@
+package com.knowledgepixels.registry;
+
+import com.mongodb.client.ClientSession;
+import io.vertx.ext.web.RoutingContext;
+import org.bson.Document;
+
+import java.io.IOException;
+
+import static com.knowledgepixels.registry.RegistryDB.collection;
+
+/**
+ * Serves hash-keyed trust state snapshots at <code>/trust-state/&lt;hash&gt;.json</code>.
+ *
+ * <p>Content is immutable once a hash is known. Consumers use this endpoint after
+ * detecting a hash change (via the {@code Nanopub-Registry-Trust-State-Hash} response
+ * header) to load the corresponding snapshot side-by-side with the previous one.
+ */
+public class TrustStatePage extends Page {
+
+    public static void show(RoutingContext context) {
+        TrustStatePage page;
+        try (ClientSession s = RegistryDB.getClient().startSession()) {
+            s.startTransaction();
+            page = new TrustStatePage(s, context);
+            page.show();
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        } finally {
+            context.response().end();
+        }
+    }
+
+    private TrustStatePage(ClientSession mongoSession, RoutingContext context) {
+        super(mongoSession, context);
+    }
+
+    protected void show() throws IOException {
+        RoutingContext c = getContext();
+        String req = getRequestString();
+        String ext = getExtension();
+
+        // Only the .json extension is supported.
+        if (!"json".equals(ext)) {
+            c.response().setStatusCode(400).setStatusMessage("Invalid request: " + getFullRequest());
+            return;
+        }
+
+        // Path must be /trust-state/<hash>. The hash character set is intentionally
+        // permissive (404 on lookup miss is the authoritative check).
+        if (!req.matches("/trust-state/[A-Za-z0-9_\\-]+")) {
+            c.response().setStatusCode(400).setStatusMessage("Invalid request: " + getFullRequest());
+            return;
+        }
+
+        String hash = req.substring("/trust-state/".length());
+        Document snapshot = collection(Collection.TRUST_STATE_SNAPSHOTS.toString())
+                .find(mongoSession, new Document("_id", hash)).first();
+        if (snapshot == null) {
+            c.response().setStatusCode(404).setStatusMessage("Trust state snapshot not found");
+            return;
+        }
+
+        setRespContentType("application/json");
+        // Content is immutable by construction: the URL encodes a hash that never rewrites.
+        c.response().putHeader("Cache-Control", "public, immutable, max-age=31536000");
+
+        // Serialize as an envelope so consumers can verify the hash and sort by counter
+        // without reparsing the URL. _id (= hash) is renamed to trustStateHash in the output.
+        Document output = new Document()
+                .append("trustStateHash", snapshot.getString("_id"))
+                .append("trustStateCounter", snapshot.get("trustStateCounter"))
+                .append("createdAt", snapshot.get("createdAt"))
+                .append("accounts", snapshot.get("accounts"));
+        print(output.toJson());
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/registry/db/IndexInitializer.java
+++ b/src/main/java/com/knowledgepixels/registry/db/IndexInitializer.java
@@ -59,6 +59,9 @@ public final class IndexInitializer {
         collection("hashes").createIndex(mongoSession, ascending("value"), unique);
 
         collection(Collection.PEER_STATE.toString()).createIndex(mongoSession, ascending("setupId"));
+
+        // Supports pruning in RELEASE_DATA: sort by trustStateCounter desc, skip N, delete the tail.
+        collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).createIndex(mongoSession, descending("trustStateCounter"));
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/registry/TrustStatePageTest.java
+++ b/src/test/java/com/knowledgepixels/registry/TrustStatePageTest.java
@@ -1,0 +1,146 @@
+package com.knowledgepixels.registry;
+
+import com.mongodb.MongoClient;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class TrustStatePageTest {
+
+    private static final String HASH = "abc123def456";
+
+    private Document makeSnapshot() {
+        List<Document> accounts = List.of(
+                new Document("pubkey", "pk1").append("agent", "https://orcid.org/0000-0000-0000-0001")
+                        .append("status", "loaded").append("depth", 1).append("pathCount", 2)
+                        .append("ratio", 0.5).append("quota", 1000),
+                new Document("pubkey", "pk2").append("agent", "https://orcid.org/0000-0000-0000-0002")
+                        .append("status", "loaded").append("depth", 2).append("pathCount", 1)
+                        .append("ratio", 0.25).append("quota", 500)
+        );
+        return new Document("_id", HASH)
+                .append("trustStateCounter", 42L)
+                .append("createdAt", "2026-04-15T12:00:00Z")
+                .append("accounts", accounts);
+    }
+
+    @Test
+    void returns200WithEnvelopeForExistingHash() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            HttpServerResponse response = setupMocks(dbMock, "/trust-state/" + HASH + ".json", makeSnapshot());
+            verify(response, never()).setStatusCode(anyInt());
+            verify(response).putHeader("Content-Type", "application/json");
+            verify(response).putHeader("Cache-Control", "public, immutable, max-age=31536000");
+
+            ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+            verify(response, atLeastOnce()).write(body.capture());
+            String fullBody = String.join("", body.getAllValues());
+            assertTrue(fullBody.contains("\"trustStateHash\""), "envelope includes trustStateHash");
+            assertTrue(fullBody.contains(HASH), "envelope echoes the hash");
+            assertTrue(fullBody.contains("\"trustStateCounter\""), "envelope includes counter");
+            assertTrue(fullBody.contains("\"accounts\""), "envelope includes accounts array");
+            assertTrue(fullBody.contains("pk1") && fullBody.contains("pk2"), "accounts are serialized");
+        }
+    }
+
+    @Test
+    void returns404WhenHashNotFound() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            HttpServerResponse response = setupMocks(dbMock, "/trust-state/missing.json", null);
+            verify(response).setStatusCode(404);
+            verify(response, never()).putHeader(eq("Cache-Control"), anyString());
+        }
+    }
+
+    @Test
+    void returns400WhenExtensionIsNotJson() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            // .html request: extension != "json" → 400, no DB lookup
+            HttpServerResponse response = setupMocks(dbMock, "/trust-state/" + HASH + ".html", null);
+            verify(response).setStatusCode(400);
+        }
+    }
+
+    @Test
+    void returns400WhenPathMalformed() {
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            // No hash segment at all: "/trust-state/.json" → empty hash fails the regex
+            HttpServerResponse response = setupMocks(dbMock, "/trust-state/.json", null);
+            verify(response).setStatusCode(400);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private HttpServerResponse setupMocks(MockedStatic<RegistryDB> dbMock, String path, Document snapshotDoc) {
+        MongoClient mongoClient = mock(MongoClient.class);
+        ClientSession session = mock(ClientSession.class);
+        dbMock.when(RegistryDB::getClient).thenReturn(mongoClient);
+        when(mongoClient.startSession()).thenReturn(session);
+
+        // Page base-class needs serverInfo + nanopubs + counter lookups.
+        MongoCollection<Document> serverInfoCollection = mock(MongoCollection.class);
+        FindIterable<Document> serverInfoFindIterable = mock(FindIterable.class);
+        dbMock.when(() -> RegistryDB.collection(Collection.SERVER_INFO.toString())).thenReturn(serverInfoCollection);
+        List<Document> serverInfoDocs = List.of(
+                new Document("_id", "status").append("value", "ready"),
+                new Document("_id", "setupId").append("value", 1L),
+                new Document("_id", "trustStateCounter").append("value", 0L),
+                new Document("_id", "lastTrustStateUpdate").append("value", ""),
+                new Document("_id", "trustStateHash").append("value", ""),
+                new Document("_id", "testInstance").append("value", false)
+        );
+        when(serverInfoCollection.find(session)).thenReturn(serverInfoFindIterable);
+        when(serverInfoFindIterable.iterator()).thenAnswer(inv -> {
+            Iterator<Document> it = serverInfoDocs.iterator();
+            MongoCursor<Document> cursor = mock(MongoCursor.class);
+            when(cursor.hasNext()).thenAnswer(i -> it.hasNext());
+            when(cursor.next()).thenAnswer(i -> it.next());
+            return cursor;
+        });
+        when(serverInfoFindIterable.spliterator()).thenAnswer(inv -> serverInfoDocs.spliterator());
+
+        MongoCollection<Document> nanopubs = mock(MongoCollection.class);
+        dbMock.when(() -> RegistryDB.collection(Collection.NANOPUBS.toString())).thenReturn(nanopubs);
+        when(nanopubs.estimatedDocumentCount()).thenReturn(0L);
+        dbMock.when(() -> RegistryDB.getMaxValue(session, Collection.NANOPUBS.toString(), "counter")).thenReturn(0L);
+
+        // Snapshot lookup.
+        MongoCollection<Document> snapshots = mock(MongoCollection.class);
+        FindIterable<Document> snapshotFind = mock(FindIterable.class);
+        dbMock.when(() -> RegistryDB.collection(Collection.TRUST_STATE_SNAPSHOTS.toString())).thenReturn(snapshots);
+        when(snapshots.find(eq(session), any(Document.class))).thenReturn(snapshotFind);
+        when(snapshotFind.first()).thenReturn(snapshotDoc);
+
+        RoutingContext context = mock(RoutingContext.class);
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        HttpServerResponse response = mock(HttpServerResponse.class);
+        when(context.request()).thenReturn(request);
+        when(context.response()).thenReturn(response);
+        when(request.path()).thenReturn(path);
+        when(response.setChunked(anyBoolean())).thenReturn(response);
+        when(response.putHeader(anyString(), anyString())).thenReturn(response);
+        when(response.setStatusCode(anyInt())).thenReturn(response);
+        when(response.setStatusMessage(anyString())).thenReturn(response);
+        when(response.write(anyString())).thenReturn(null);
+
+        TrustStatePage.show(context);
+
+        return response;
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/registry/TrustStatePageTest.java
+++ b/src/test/java/com/knowledgepixels/registry/TrustStatePageTest.java
@@ -68,10 +68,10 @@ class TrustStatePageTest {
     }
 
     @Test
-    void returns400WhenExtensionIsNotJson() {
+    void returns400WhenExtensionIsUnsupported() {
         try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
-            // .html request: extension != "json" → 400, no DB lookup
-            HttpServerResponse response = setupMocks(dbMock, "/trust-state/" + HASH + ".html", null);
+            // .xml is not in the supported set → 400 before any DB lookup
+            HttpServerResponse response = setupMocks(dbMock, "/trust-state/" + HASH + ".xml", null);
             verify(response).setStatusCode(400);
         }
     }
@@ -79,8 +79,8 @@ class TrustStatePageTest {
     @Test
     void returns400WhenPathMalformed() {
         try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
-            // No hash segment at all: "/trust-state/.json" → empty hash fails the regex
-            HttpServerResponse response = setupMocks(dbMock, "/trust-state/.json", null);
+            // Hash contains disallowed character → doesn't match the regex, isn't the list path
+            HttpServerResponse response = setupMocks(dbMock, "/trust-state/bad!hash.json", null);
             verify(response).setStatusCode(400);
         }
     }

--- a/src/test/java/com/knowledgepixels/registry/db/IndexInitializerTest.java
+++ b/src/test/java/com/knowledgepixels/registry/db/IndexInitializerTest.java
@@ -49,6 +49,7 @@ class IndexInitializerTest {
         assertEquals(5, getNumberOfIndexes("invalidations"));
         assertEquals(8, getNumberOfIndexes("trustEdges"));
         assertEquals(3, getNumberOfIndexes("hashes"));
+        assertEquals(2, getNumberOfIndexes(Collection.TRUST_STATE_SNAPSHOTS.toString()));
     }
 
     @Test


### PR DESCRIPTION
Implements #107.

## Plan

- [x] **Step 1.** Add `TRUST_STATE_SNAPSHOTS` collection enum entry
- [x] **Step 2.** Snapshot writer in `RELEASE_DATA` (projects `accounts` → structured snapshot, one doc per hash)
- [x] **Step 3.** Retention (keep last 100, const for now)
- [x] **Step 4.** Index on `trustStateCounter` for pruning + update `IndexInitializerTest`
- [x] **Step 5.** `TrustStatePage` serving `/trust-state/<hash>.json`
- [x] **Step 6.** Route registration in `MainVerticle`
- [x] **Step 7.** Tests (`TrustStatePageTest`)
- [x] **Step 8.** `design.md` update

Ready for review — marking as ready.

## Decisions baked in

- Retention N = 100, as a constant (private static final in RELEASE_DATA)
- Full schema: `{pubkey, agent, status, depth, pathCount, ratio, quota}`
- Envelope output: `{trustStateHash, trustStateCounter, createdAt, accounts}` (not just the raw array — makes the payload self-describing and extensible)
- No ETag — URL identity keys the content, `Cache-Control: public, immutable, max-age=31536000`

## Risks to review

- **Doc-size ceiling.** Snapshot embeds the accounts array in a single MongoDB doc (16MB limit). At ~200 bytes/account that's ~80k accounts of headroom. Current registry is well below that. If account count grows, migrate to one-doc-per-account with composite `{snapshotHash, pubkey}` keys.
- **Transaction scope.** `accounts.find(s)` runs in the same transaction as the snapshot insert and the prune. Fine for current scale; cf. the `ListPage` comment about jelly streams not fitting in transactions if this ever becomes a concern.

## Test coverage

- `TrustStatePageTest`: 200 envelope, 404 on missing hash, 400 on non-`.json` extension, 400 on malformed path.
- `IndexInitializerTest`: asserts the new `trustStateSnapshots` index.
- Full `mvn test` run passes locally.

Not covered yet (future work): end-to-end snapshot writer test (requires running the trust-calculation pipeline in an integration test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)