### PR TITLE
docs: replace defunct trustyuri public instance with registry.nanodash.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This code base is in beta phase.
 
 These are some currently running instances:
 
-- https://registry.np.trustyuri.net/
+- https://registry.nanodash.net/
 - https://registry.knowledgepixels.com/
 - https://registry.petapico.org/
 


### PR DESCRIPTION
## Summary

- The trustyuri-hosted registry at \`registry.np.trustyuri.net\` is no longer up.
- Replaced with the currently-running instance at \`registry.nanodash.net\`.

## Test plan

- [ ] README renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)