### PR TITLE
chore(deps): apply available dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,19 +167,19 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>2.0.3</version>
+      <version>2.0.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-junit-jupiter</artifactId>
-      <version>2.0.3</version>
+      <version>2.0.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-mongodb</artifactId>
-      <version>2.0.3</version>
+      <version>2.0.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
     <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <vertx.version>4.5.26</vertx.version>
     <junit-jupiter.version>5.11.4</junit-jupiter.version>
 
-    <rdf4j.version>5.1.2</rdf4j.version>
+    <rdf4j.version>5.3.0</rdf4j.version>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.22.0</version>
+      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.nanopub</groupId>
       <artifactId>nanopub</artifactId>
-      <version>1.86.1</version>
+      <version>1.86.2</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
     <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
 
-    <vertx.version>4.5.11</vertx.version>
+    <vertx.version>4.5.26</vertx.version>
     <junit-jupiter.version>5.11.4</junit-jupiter.version>
 
     <rdf4j.version>5.1.2</rdf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -146,12 +146,12 @@
     <dependency>
       <groupId>eu.neverblink.jelly</groupId>
       <artifactId>jelly-rdf4j</artifactId>
-      <version>3.7.1</version>
+      <version>3.7.2</version>
     </dependency>
     <dependency>
       <groupId>eu.neverblink.jelly</groupId>
       <artifactId>jelly-core-protos-google</artifactId>
-      <version>3.7.1</version>
+      <version>3.7.2</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>


### PR DESCRIPTION
## Summary
Bumps several dependencies and one Maven plugin to their latest compatible versions. Each bump is in its own commit for easier review/bisection.

- `vertx` 4.5.11 → 4.5.26 (stays on 4.5 line; 5.x is a major upgrade and is intentionally deferred)
- `rdf4j` 5.1.2 → 5.3.0
- `nanopub` 1.86.1 → 1.86.2
- `jelly-rdf4j` / `jelly-core-protos-google` 3.7.1 → 3.7.2
- `mockito-core` 5.22.0 → 5.23.0
- `testcontainers` (+ junit-jupiter, + mongodb) 2.0.3 → 2.0.5
- `maven-compiler-plugin` 3.11.0 → 3.15.0

Verified `./mvnw clean compile test-compile` succeeds locally.

## Test plan
- [ ] CI passes (build, unit tests, integration tests)
- [ ] No regressions in RDF4J/Vert.x-handled request paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)