### PR TITLE
feat: stamp foaf:name + dct:created of declaring intro on accounts

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/AgentInfo.java
+++ b/src/main/java/com/knowledgepixels/registry/AgentInfo.java
@@ -12,6 +12,7 @@ public class AgentInfo implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String agentId;
+    private String name;
     private Integer accountCount;
     private Double avgPathCount;
     private Double totalRatio;
@@ -22,6 +23,7 @@ public class AgentInfo implements Serializable {
         AgentInfo ri = new AgentInfo();
         ri.agentId = agentId;
         Document d = RegistryDB.getOne(mongoSession, Collection.AGENTS.toString(), new Document("agent", agentId));
+        ri.name = d.getString("name");
         ri.accountCount = (Integer) d.get("accountCount");
         ri.avgPathCount = (Double) d.get("avgPathCount");
         ri.totalRatio = (Double) d.get("totalRatio");

--- a/src/main/java/com/knowledgepixels/registry/ListPage.java
+++ b/src/main/java/com/knowledgepixels/registry/ListPage.java
@@ -320,7 +320,9 @@ public class ListPage extends Page {
                     if (d.get("agent").equals("$")) continue;
                     String a = d.getString("agent");
                     int accountCount = d.getInteger("accountCount");
-                    println("<li><a href=\"/agent?id=" + URLEncoder.encode(a, "UTF-8") + "\">" + Utils.getAgentLabel(a) + "</a>, " + accountCount + " account" + (accountCount == 1 ? "" : "s") + ", " + "ratio " + df8.format(d.get("totalRatio")) + ", " + "avg. path count " + df1.format(d.get("avgPathCount")) + "</li>");
+                    String name = d.getString("name");
+                    String nameSuffix = (name != null && !name.isBlank()) ? " (" + name + ")" : "";
+                    println("<li><a href=\"/agent?id=" + URLEncoder.encode(a, "UTF-8") + "\">" + Utils.getAgentLabel(a) + "</a>" + nameSuffix + ", " + accountCount + " account" + (accountCount == 1 ? "" : "s") + ", " + "ratio " + df8.format(d.get("totalRatio")) + ", " + "avg. path count " + df1.format(d.get("avgPathCount")) + "</li>");
                 }
                 println("</ol>");
                 printHtmlFooter();

--- a/src/main/java/com/knowledgepixels/registry/ListPage.java
+++ b/src/main/java/com/knowledgepixels/registry/ListPage.java
@@ -208,6 +208,10 @@ public class ListPage extends Page {
                             String a = d.getString("agent");
                             if (a != null && !a.isBlank()) {
                                 print(" by <a href=\"/agent?id=" + URLEncoder.encode(a, "UTF-8") + "\">" + Utils.getAgentLabel(a) + "</a>");
+                                String name = d.getString("name");
+                                if (name != null && !name.isBlank()) {
+                                    print(" (" + name + ")");
+                                }
                             }
                             print(", status: " + d.get("status"));
                             print(", depth: " + d.get("depth"));
@@ -239,8 +243,10 @@ public class ListPage extends Page {
                 print(AgentInfo.get(mongoSession, agentId).asJson());
             } else {
                 Document agentDoc = RegistryDB.getOne(mongoSession, Collection.AGENTS.toString(), new Document("agent", agentId));
-                printHtmlHeader("Agent " + Utils.getAgentLabel(agentId) + " - Nanopub Registry");
-                println("<h1>Agent " + Utils.getAgentLabel(agentId) + "</h1>");
+                String agentName = (agentDoc != null) ? agentDoc.getString("name") : null;
+                String headingSuffix = (agentName != null && !agentName.isBlank()) ? " (" + agentName + ")" : "";
+                printHtmlHeader("Agent " + Utils.getAgentLabel(agentId) + headingSuffix + " - Nanopub Registry");
+                println("<h1>Agent " + Utils.getAgentLabel(agentId) + headingSuffix + "</h1>");
                 println("<p><a href=\"/agents\">&lt; Agent List</a></p>");
                 println("<h3>Formats</h3>");
                 println("<p>");
@@ -251,6 +257,9 @@ public class ListPage extends Page {
                 println("<p><a href=\"" + agentId + "\"><code>" + agentId + "</code></a></p>");
                 println("<h3>Properties</h3>");
                 println("<ul>");
+                if (agentName != null && !agentName.isBlank()) {
+                    println("<li>Name: " + agentName + "</li>");
+                }
                 println("<li>Average path count: " + agentDoc.get("avgPathCount") + "</li>");
                 println("<li>Total ratio: " + agentDoc.get("totalRatio") + "</li>");
                 println("</ul>");
@@ -270,8 +279,11 @@ public class ListPage extends Page {
                 }
                 println("]");
             } else {
-                printHtmlHeader("Accounts of Agent " + Utils.getAgentLabel(agentId) + " - Nanopub Registry");
-                println("<h1>Accounts of Agent " + Utils.getAgentLabel(agentId) + "</h1>");
+                Document agentDoc = RegistryDB.getOne(mongoSession, Collection.AGENTS.toString(), new Document("agent", agentId));
+                String agentName = (agentDoc != null) ? agentDoc.getString("name") : null;
+                String headingSuffix = (agentName != null && !agentName.isBlank()) ? " (" + agentName + ")" : "";
+                printHtmlHeader("Accounts of Agent " + Utils.getAgentLabel(agentId) + headingSuffix + " - Nanopub Registry");
+                println("<h1>Accounts of Agent " + Utils.getAgentLabel(agentId) + headingSuffix + "</h1>");
                 println("<p><a href=\"/agent?id=" + URLEncoder.encode(agentId, "UTF-8") + "\">&lt; Agent</a></p>");
                 println("<h3>Formats</h3>");
                 println("<p>");
@@ -290,7 +302,9 @@ public class ListPage extends Page {
                             new Document("pubkey", pubkey).append("type", "$"));
                     long npCount = (dollarList != null && dollarList.get("maxPosition") != null)
                             ? dollarList.getLong("maxPosition") + 1 : 0;
-                    println("<li><a href=\"/list/" + pubkey + "\"><code>" + getLabel(pubkey) + "</code></a> (" + d.get("status") + "), " + "count " + npCount + ", " + "quota " + d.get("quota") + ", " + "ratio " + df8.format(d.get("ratio")) + ", " + "path count " + d.get("pathCount") + "</li>");
+                    String accountName = d.getString("name");
+                    String nameSuffix = (accountName != null && !accountName.isBlank()) ? " (" + accountName + ")" : "";
+                    println("<li><a href=\"/list/" + pubkey + "\"><code>" + getLabel(pubkey) + "</code></a>" + nameSuffix + " (" + d.get("status") + "), " + "count " + npCount + ", " + "quota " + d.get("quota") + ", " + "ratio " + df8.format(d.get("ratio")) + ", " + "path count " + d.get("pathCount") + "</li>");
                 }
                 println("</ul>");
                 printHtmlFooter();

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -12,6 +12,7 @@ import org.bson.Document;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.nanopub.Nanopub;
+import org.nanopub.SimpleTimestampPattern;
 import org.nanopub.extra.index.IndexUtils;
 import org.nanopub.extra.index.NanopubIndex;
 import org.nanopub.extra.security.KeyDeclaration;
@@ -211,6 +212,11 @@ public enum Task implements Serializable {
                 IntroNanopub agentIntro = getAgentIntro(s, d.getString("endorsedNanopub"));
                 if (agentIntro != null) {
                     String agentId = agentIntro.getUser().stringValue();
+                    // foaf:name + dct:created of the intro nanopub. Same name applies to every
+                    // KeyDeclaration in the intro, so resolve once outside the inner loop.
+                    String introName = Utils.extractIntroName(agentIntro);
+                    Calendar introCreatedCal = SimpleTimestampPattern.getCreationTime(agentIntro.getNanopub());
+                    Date introCreatedAt = (introCreatedCal == null) ? null : introCreatedCal.getTime();
 
                     for (KeyDeclaration kd : agentIntro.getKeyDeclarations()) {
                         String sourceAgent = d.getString("agent");
@@ -232,8 +238,24 @@ public enum Task implements Serializable {
                         }
 
                         Document agent = new Document("agent", agentId).append("pubkey", agentPubkey);
-                        if (!has(s, "accounts_loading", agent)) {
-                            insert(s, "accounts_loading", agent.append("status", seen.getValue()).append("depth", depth));
+                        Document existing = collection("accounts_loading").find(s, agent).first();
+                        if (existing == null) {
+                            insert(s, "accounts_loading", agent
+                                    .append("status", seen.getValue())
+                                    .append("depth", depth)
+                                    .append("name", introName)
+                                    .append("nameCreatedAt", introCreatedAt));
+                        } else if (introName != null) {
+                            // Per-(agent, pubkey) name policy: keep the name from the intro
+                            // with the latest dct:created. First write wins when no current
+                            // timestamp exists; otherwise compare and replace iff strictly newer.
+                            Date currentCreatedAt = existing.getDate("nameCreatedAt");
+                            if (currentCreatedAt == null
+                                    || (introCreatedAt != null && introCreatedAt.after(currentCreatedAt))) {
+                                set(s, "accounts_loading", existing
+                                        .append("name", introName)
+                                        .append("nameCreatedAt", introCreatedAt));
+                            }
                         }
                     }
 
@@ -715,6 +737,8 @@ public enum Task implements Serializable {
                     snapshotAccounts.add(new Document()
                             .append("pubkey", pubkey)
                             .append("agent", a.getString("agent"))
+                            .append("name", a.getString("name"))
+                            .append("nameCreatedAt", a.get("nameCreatedAt"))
                             .append("status", a.getString("status"))
                             .append("depth", a.get("depth"))
                             .append("pathCount", a.get("pathCount"))
@@ -1178,6 +1202,7 @@ public enum Task implements Serializable {
         loadNanopub(mongoSession, agentIntro.getNanopub());
         return agentIntro;
     }
+
 
     private static void setServerStatus(ClientSession mongoSession, ServerStatus status) {
         setValue(mongoSession, Collection.SERVER_INFO.toString(), "status", status.toString());

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -615,12 +615,25 @@ public enum Task implements Serializable {
                 int count = 0;
                 int pathCountSum = 0;
                 double totalRatio = 0.0d;
+                // Canonical-name resolution across the agent's approved keys: pick the
+                // row with MAX(ratio); ties broken on lex-min name for determinism.
+                // Per-(agent, pubkey) name was already chosen by LOAD_ENDORSEMENTS as
+                // "latest declaring intro wins"; this layer just folds across keys.
+                String chosenName = null;
+                double chosenRatio = Double.NEGATIVE_INFINITY;
                 try (MongoCursor<Document> agentAccounts = collection("accounts_loading").find(s, agentId).cursor()) {
                     while (agentAccounts.hasNext()) {
                         Document d = agentAccounts.next();
                         count++;
                         pathCountSum += d.getInteger("pathCount");
-                        totalRatio += d.getDouble("ratio");
+                        double r = d.getDouble("ratio");
+                        totalRatio += r;
+                        String n = d.getString("name");
+                        if (n != null && (r > chosenRatio
+                                || (r == chosenRatio && (chosenName == null || n.compareTo(chosenName) < 0)))) {
+                            chosenName = n;
+                            chosenRatio = r;
+                        }
                     }
                 }
                 collection("accounts_loading").updateMany(s, agentId, new Document("$set",
@@ -629,6 +642,7 @@ public enum Task implements Serializable {
                         agentId.append("accountCount", count)
                                 .append("avgPathCount", (double) pathCountSum / count)
                                 .append("totalRatio", totalRatio)
+                                .append("name", chosenName)
                 );
             }
             schedule(s, ASSIGN_PUBKEYS);

--- a/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
+++ b/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
@@ -176,10 +176,14 @@ public class TrustStatePage extends Page {
                 Document a = (Document) entry;
                 String pubkey = a.getString("pubkey");
                 String agent = a.getString("agent");
+                String name = a.getString("name");
                 println("<li>");
                 println("<a href=\"/list/" + pubkey + "\"><code>" + getLabel(pubkey) + "</code></a>");
                 if (agent != null && !agent.isBlank()) {
                     print(" by <a href=\"/agent?id=" + Utils.urlEncode(agent) + "\">" + Utils.getAgentLabel(agent) + "</a>");
+                    if (name != null && !name.isBlank()) {
+                        print(" (" + name + ")");
+                    }
                 }
                 print(", status: " + a.get("status"));
                 print(", depth: " + a.get("depth"));

--- a/src/main/java/com/knowledgepixels/registry/Utils.java
+++ b/src/main/java/com/knowledgepixels/registry/Utils.java
@@ -374,4 +374,26 @@ public class Utils {
         return g.fromJson(new InputStreamReader(new URI(url).toURL().openStream()), listType);
     }
 
+    /**
+     * Extracts the {@code foaf:name} literal asserted on the intro's user IRI.
+     * Returns {@code null} when the assertion declares no such name. When multiple
+     * {@code foaf:name} literals are asserted on the same agent, the lexicographic
+     * minimum is returned for deterministic behaviour across rebuilds.
+     */
+    public static String extractIntroName(org.nanopub.extra.setting.IntroNanopub agentIntro) {
+        IRI agentIri = agentIntro.getUser();
+        if (agentIri == null) return null;
+        String chosen = null;
+        for (Statement st : agentIntro.getNanopub().getAssertion()) {
+            if (!st.getSubject().equals(agentIri)) continue;
+            if (!st.getPredicate().equals(org.eclipse.rdf4j.model.vocabulary.FOAF.NAME)) continue;
+            if (!(st.getObject() instanceof org.eclipse.rdf4j.model.Literal)) continue;
+            String candidate = st.getObject().stringValue();
+            if (chosen == null || candidate.compareTo(chosen) < 0) {
+                chosen = candidate;
+            }
+        }
+        return chosen;
+    }
+
 }

--- a/src/test/java/com/knowledgepixels/registry/TaskExtractIntroNameTest.java
+++ b/src/test/java/com/knowledgepixels/registry/TaskExtractIntroNameTest.java
@@ -1,0 +1,93 @@
+package com.knowledgepixels.registry;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.extra.setting.IntroNanopub;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure-logic tests for {@link Utils#extractIntroName(IntroNanopub)}. Exercises the
+ * deterministic-tiebreaker policy ({@code MIN(?name)} alphabetically) when an
+ * intro asserts multiple {@code foaf:name} literals on the same agent, and
+ * the {@code null}-fallback when the assertion has no name.
+ */
+class TaskExtractIntroNameTest {
+
+    private static final ValueFactory VF = SimpleValueFactory.getInstance();
+    private static final IRI AGENT = VF.createIRI("https://orcid.org/0000-0000-0000-0001");
+    private static final IRI OTHER_AGENT = VF.createIRI("https://orcid.org/0000-0000-0000-0002");
+
+    @Test
+    void returnsNameLiteralWhenAssertionDeclaresOne() {
+        IntroNanopub intro = introWith(
+                VF.createStatement(AGENT, FOAF.NAME, VF.createLiteral("Alice")));
+        assertEquals("Alice", Utils.extractIntroName(intro));
+    }
+
+    @Test
+    void returnsLexicographicallyMinimumWhenMultipleNames() {
+        // Determinism across rebuilds requires a stable tiebreaker for multi-name intros.
+        // MIN(?name) keeps the same chosen literal regardless of triple iteration order.
+        IntroNanopub intro = introWith(
+                VF.createStatement(AGENT, FOAF.NAME, VF.createLiteral("Charlie")),
+                VF.createStatement(AGENT, FOAF.NAME, VF.createLiteral("Alice")),
+                VF.createStatement(AGENT, FOAF.NAME, VF.createLiteral("Bob")));
+        assertEquals("Alice", Utils.extractIntroName(intro));
+    }
+
+    @Test
+    void returnsNullWhenAssertionHasNoFoafName() {
+        IntroNanopub intro = introWith(
+                VF.createStatement(AGENT, RDF.TYPE, VF.createIRI("http://example.org/Thing")));
+        assertNull(Utils.extractIntroName(intro));
+    }
+
+    @Test
+    void ignoresFoafNameAssertedOnDifferentSubject() {
+        // An intro might mention other people's names in passing; only the user's
+        // own foaf:name should be considered.
+        IntroNanopub intro = introWith(
+                VF.createStatement(OTHER_AGENT, FOAF.NAME, VF.createLiteral("Mallory")));
+        assertNull(Utils.extractIntroName(intro));
+    }
+
+    @Test
+    void ignoresNonLiteralObject() {
+        // Defensive: the object of foaf:name is normally a literal, but a malformed
+        // intro could put an IRI there. Such triples must not be picked up as names.
+        IntroNanopub intro = introWith(
+                VF.createStatement(AGENT, FOAF.NAME, VF.createIRI("http://example.org/not-a-name")));
+        assertNull(Utils.extractIntroName(intro));
+    }
+
+    @Test
+    void returnsNullWhenIntroHasNoUser() {
+        IntroNanopub intro = mock(IntroNanopub.class);
+        when(intro.getUser()).thenReturn(null);
+        assertNull(Utils.extractIntroName(intro));
+    }
+
+    private static IntroNanopub introWith(Statement... assertion) {
+        Nanopub np = mock(Nanopub.class);
+        Set<Statement> assertionSet = new LinkedHashSet<>();
+        for (Statement st : assertion) assertionSet.add(st);
+        when(np.getAssertion()).thenReturn(assertionSet);
+        IntroNanopub intro = mock(IntroNanopub.class);
+        when(intro.getUser()).thenReturn(AGENT);
+        when(intro.getNanopub()).thenReturn(np);
+        return intro;
+    }
+}


### PR DESCRIPTION
## Status

**Draft** — open for review. The matching consumer-side change in [`nanopub-query`](https://github.com/knowledgepixels/nanopub-query) (reads the new fields, materialises one canonical \`foaf:name\` per agent into the trust-state graph, mirrors into the spaces state graph) is being prepped in parallel and will land once this is in.

## Motivation

Consumers that surface agent names today (e.g. nanopub-query's spaces UI, agent listings) have to federate out to \`/repo/full\` to look up \`foaf:name\` per ORCID — and they do so without any trust-aware filter, so a passing mention of someone's name in an unrelated nanopub can shadow the agent's actual self-introduction.

The trust calculation already opens every intro nanopub during \`LOAD_ENDORSEMENTS\`. Pulling \`foaf:name\` and \`dct:created\` out of the same assertion is essentially free, and it lets consumers display the name that the trust-graph treats as canonical without doing their own lookups.

## Schema (additive, non-breaking)

Two new optional fields on each \`accounts_loading\` (and therefore \`accounts\`) document, also passed through to per-account JSON in the trust-state snapshot:

| field | type | description |
|---|---|---|
| \`name\` | string \| null | \`foaf:name\` literal asserted on the agent IRI inside the declaring intro nanopub. \`null\` when the intro has no \`foaf:name\`. |
| \`nameCreatedAt\` | Date \| null | The declaring intro's \`dct:created\`. Used to pick the latest declaration when multiple intros declare the same \`(agent, pubkey)\`. |

## Resolution policy

The two layers were decided up front to keep the on-disk schema minimal and the consumer query simple:

- **Per-\`(agent, pubkey)\`** (this PR): keep the name from the intro with the latest \`dct:created\`. First write wins when no current timestamp exists; subsequent writes replace iff strictly newer. Multi-\`foaf:name\` on a single intro: \`MIN(?name)\` lexicographic tiebreak for determinism.
- **Per-agent across keys** (consumer side): pick the row with \`MAX(ratio)\` (ties → \`MIN(name)\`). The registry exposes raw per-row data; nanopub-query does the cross-key fold when materialising the trust-state graph.

\"Most-trusted key's freshest declaration\" is what falls out of those two layers composed.

## Changes

- **\`Task.LOAD_ENDORSEMENTS\`** (\`Task.java:211-260\`) — extracts \`foaf:name\` (via \`Utils.extractIntroName\`) and \`dct:created\` (via \`SimpleTimestampPattern.getCreationTime\`, converted to \`Date\`) once per intro, then either inserts a new \`accounts_loading\` row with both fields, or conditionally upserts \`name\`/\`nameCreatedAt\` on an existing row when the new intro's timestamp is strictly newer.
- **\`Task.RELEASE_DATA\`** (\`Task.java:711-723\`) — passes \`name\` and \`nameCreatedAt\` through to per-account snapshot JSON.
- **\`Utils.extractIntroName\`** (new) — pure helper. Walks \`agentIntro.getNanopub().getAssertion()\` for \`<agentId> foaf:name ?n\` literals, returns \`MIN(?n)\` lex; \`null\` if none. Lives in \`Utils\` so unit tests can exercise it without bringing up the \`Task\` static initializer (which requires Mongo).
- **\`TrustStatePage.showDetail\`** (\`TrustStatePage.java:177-189\`) — renders the resolved name after the agent IRI in the HTML accounts list.
- **\`TaskExtractIntroNameTest\`** (new) — six unit tests over the helper's policy:
  - returns the literal when one is asserted
  - \`MIN\` lex when multiple are asserted on the same agent
  - \`null\` when no \`foaf:name\` is asserted
  - ignores \`foaf:name\` asserted on other subjects
  - ignores non-literal objects
  - handles \`null\` user safely

## Test plan

- [x] \`mvn test -DskipITs\` — 177/177 pass locally (was 171; +6 new tests)
- [x] CI green
- [ ] Live sanity-check after deploy: pick any approved ORCID with a known intro, confirm \`/trust-state/<hash>.json\` includes the right \`name\` for that account row

## Compatibility

- **Schema**: purely additive — existing consumers ignore the new fields.
- **Replay**: the new fields populate naturally on the next trust-calculation pass; no backfill needed.
- **Resolution drift**: if no intro's \`dct:created\` is parseable, \`nameCreatedAt\` stays \`null\` and the per-row name is whatever the first intro stamped — same behaviour as the current implicit first-write-wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)