### PR TITLE
chore(deps): bump rdf4j, nanopub, mongodb-driver-sync, gson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.13.2</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver-sync</artifactId>
-      <version>4.10.0</version>
+      <version>4.11.5</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.nanopub</groupId>
       <artifactId>nanopub</artifactId>
-      <version>1.86.2</version>
+      <version>1.87.1</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
   <dependencies>
     <dependency>
       <groupId>org.nanopub</groupId>
+      <artifactId>nanopub</artifactId>
+      <version>1.87.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.nanopub</groupId>
       <artifactId>nanopub-testsuite-connector</artifactId>
       <version>1.0.0</version>
       <scope>test</scope>
@@ -111,11 +116,6 @@
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-jsonld</artifactId>
       <version>${rdf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.nanopub</groupId>
-      <artifactId>nanopub</artifactId>
-      <version>1.87.1</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <vertx.version>4.5.26</vertx.version>
     <junit-jupiter.version>5.11.4</junit-jupiter.version>
 
-    <rdf4j.version>5.3.0</rdf4j.version>
+    <rdf4j.version>5.3.1</rdf4j.version>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 

--- a/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/registry/NanopubLoader.java
@@ -300,7 +300,7 @@ public class NanopubLoader {
     private static Nanopub getNanopub(String uriOrArtifactCode) {
         List<String> peerUrls = new ArrayList<>(Utils.getPeerUrls());
         Collections.shuffle(peerUrls);
-        String ac = GetNanopub.getArtifactCode(uriOrArtifactCode);
+        String ac = GetNanopub.getArtifactCode(uriOrArtifactCode).toString();
         if (!ac.startsWith(RdfModule.MODULE_ID)) {
             throw new IllegalArgumentException("Not a trusty URI of type RA");
         }


### PR DESCRIPTION
## Summary
- Bumps four direct dependencies to the latest stable patch/minor versions; held off on Vert.x 5, RDF4J 6, micrometer 1.17-RC1, and slf4j 2.1-alpha as those are major/pre-release.
- Reorders `pom.xml` so `nanopub` is declared before `nanopub-testsuite-connector`. `nanopub:1.87.1` requires `trustyuri:1.24.1` (adds `RdfHasher#makeArtifactCode(List)`) but `nanopub-testsuite-connector:1.0.0` pins `trustyuri:1.23`. Maven mediation breaks ties by declaration order, so listing `nanopub` first ensures 1.24.1 wins; without this, the test suite hits `NoSuchMethodError` at runtime.

| Dependency | From | To |
|---|---|---|
| `org.eclipse.rdf4j:rdf4j-rio-*` | 5.3.0 | 5.3.1 |
| `org.nanopub:nanopub` | 1.86.2 | 1.87.1 |
| `org.mongodb:mongodb-driver-sync` | 4.10.0 | 4.11.5 |
| `com.google.code.gson:gson` | 2.13.2 | 2.14.0 |

## Test plan
- [x] `./mvnw test` — 177 tests pass, 0 failures, 0 errors
- [x] `./mvnw dependency:tree` confirms `trustyuri:1.24.1` resolved (was `1.23`)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)