### PR TITLE
feat(trust-state): record authorizing introNanopub on account rows

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -217,6 +217,11 @@ public enum Task implements Serializable {
                     String introName = Utils.extractIntroName(agentIntro);
                     Calendar introCreatedCal = SimpleTimestampPattern.getCreationTime(agentIntro.getNanopub());
                     Date introCreatedAt = (introCreatedCal == null) ? null : introCreatedCal.getTime();
+                    // The authorizing introduction for this (agent, pubkey): it carries the
+                    // KeyDeclaration for the pubkey. Recorded alongside the name and kept in sync
+                    // with it (latest-dct:created wins), so it reflects one authorizing intro —
+                    // the name-winning one — not the complete set of intros for this account.
+                    String introNp = agentIntro.getNanopub().getUri().stringValue();
 
                     for (KeyDeclaration kd : agentIntro.getKeyDeclarations()) {
                         String sourceAgent = d.getString("agent");
@@ -244,7 +249,8 @@ public enum Task implements Serializable {
                                     .append("status", seen.getValue())
                                     .append("depth", depth)
                                     .append("name", introName)
-                                    .append("nameCreatedAt", introCreatedAt));
+                                    .append("nameCreatedAt", introCreatedAt)
+                                    .append("introNanopub", introNp));
                         } else if (introName != null) {
                             // Per-(agent, pubkey) name policy: keep the name from the intro
                             // with the latest dct:created. First write wins when no current
@@ -254,7 +260,8 @@ public enum Task implements Serializable {
                                     || (introCreatedAt != null && introCreatedAt.after(currentCreatedAt))) {
                                 set(s, "accounts_loading", existing
                                         .append("name", introName)
-                                        .append("nameCreatedAt", introCreatedAt));
+                                        .append("nameCreatedAt", introCreatedAt)
+                                        .append("introNanopub", introNp));
                             }
                         }
                     }
@@ -753,6 +760,7 @@ public enum Task implements Serializable {
                             .append("agent", a.getString("agent"))
                             .append("name", a.getString("name"))
                             .append("nameCreatedAt", a.get("nameCreatedAt"))
+                            .append("introNanopub", a.getString("introNanopub"))
                             .append("status", a.getString("status"))
                             .append("depth", a.get("depth"))
                             .append("pathCount", a.get("pathCount"))

--- a/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
+++ b/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
@@ -185,6 +185,10 @@ public class TrustStatePage extends Page {
                         print(" (" + name + ")");
                     }
                 }
+                String introNanopub = a.getString("introNanopub");
+                if (introNanopub != null && !introNanopub.isBlank()) {
+                    print(" via <a href=\"" + Utils.urlEncode(introNanopub) + "\">intro</a>");
+                }
                 print(", status: " + a.get("status"));
                 print(", depth: " + a.get("depth"));
                 if (a.get("pathCount") != null) print(", pathCount: " + a.get("pathCount"));

--- a/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
+++ b/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
@@ -3,6 +3,7 @@ package com.knowledgepixels.registry;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCursor;
 import io.vertx.ext.web.RoutingContext;
+import net.trustyuri.TrustyUriUtils;
 import org.bson.Document;
 
 import java.io.IOException;
@@ -187,7 +188,9 @@ public class TrustStatePage extends Page {
                 }
                 String introNanopub = a.getString("introNanopub");
                 if (introNanopub != null && !introNanopub.isBlank()) {
-                    print(" via <a href=\"" + Utils.urlEncode(introNanopub) + "\">intro</a>");
+                    // introNanopub is a full nanopub URI; link via the in-registry /np/<artifactCode>
+                    // convention (see ListPage), not urlEncode (that escapes the scheme too).
+                    print(" via <a href=\"/np/" + TrustyUriUtils.getArtifactCode(introNanopub) + "\">intro</a>");
                 }
                 print(", status: " + a.get("status"));
                 print(", depth: " + a.get("depth"));


### PR DESCRIPTION
Closes #117. Unblocks knowledgepixels/nanopub-query#125 finding #4.

## What

Records the **authorizing introduction nanopub** on each account row of the trust-state snapshot, so downstream consumers can recover *which* introduction approved a given key — not just *that* it was approved.

The intro is already in hand at `Task.java:212` while assembling each row (it's where `name`/`nameCreatedAt` come from, per #113). `introNanopub` is captured there and kept in sync with `name`: same per-`(agent, pubkey)` latest-`dct:created` policy, so it always reflects the name-winning intro (one authorizing intro, not the complete set — noted in a code comment).

## Changes

- **`Task.java`** — resolve `introNanopub` alongside the name; append it in both the insert branch (account first seen) and the set branch (newer intro wins, inside the existing strictly-newer guard).
- **`Task.java` snapshot builder** — the stored snapshot is an explicit field allowlist (not a verbatim copy), so the field is added there too; otherwise it would be silently dropped before reaching `TrustStatePage`.
- **`TrustStatePage.java`** — renders a `via intro` link in the HTML detail view. The JSON detail already copies `accounts` verbatim, so it surfaces there automatically.

## Notes

- **Purely additive.** Does not affect the trust-state hash (`calculateTrustStateHash` hashes `trustPaths` only), and existing consumers ignore the new field.
- **No re-ingest needed.** Trust-state recompute already rebuilds account rows from scratch each cycle, so the field auto-populates. Already-stored immutable snapshots won't gain it retroactively (fine — additive/optional). It appears in a *served* snapshot at the next genuine trust-state change (new snapshots are only written when the hash changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)