### PR TITLE
fix(trust-state): exclude toLoad accounts from snapshot hash and snapshot (#119)

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.mongodb.client.model.Indexes.ascending;
 
@@ -695,11 +697,31 @@ public class RegistryDB {
      * @return the calculated trust state hash
      */
     public static String calculateTrustStateHash(ClientSession mongoSession) {
+        // Accounts still in the 'toLoad' staging status are not yet servable and must not enter the
+        // public trust state: a path's head account flips 'toLoad' -> 'loaded' between UPDATE cycles
+        // (in LOAD_FULL) without changing any trust path, so if those paths were hashed, a leaf
+        // account's promotion would never change the hash and never trigger a new snapshot, leaving
+        // it published as 'toLoad' indefinitely (see issue #119). By excluding 'toLoad' paths here,
+        // crossing out of 'toLoad' is itself a membership change -> hash change -> emission.
+        Set<String> toLoadAccounts = new HashSet<>();
+        try (MongoCursor<Document> ac = collection("accounts_loading")
+                .find(mongoSession, new Document("status", EntryStatus.toLoad.getValue()))
+                .projection(new Document("agent", 1).append("pubkey", 1))
+                .cursor()) {
+            while (ac.hasNext()) {
+                Document a = ac.next();
+                toLoadAccounts.add(a.getString("agent") + "|" + a.getString("pubkey"));
+            }
+        }
+
         MongoCursor<Document> tp = collection("trustPaths_loading").find(mongoSession).sort(ascending("_id")).cursor();
         // TODO Improve this so we don't create the full string just for calculating its hash:
         String s = "";
         while (tp.hasNext()) {
             Document d = tp.next();
+            if (toLoadAccounts.contains(d.getString("agent") + "|" + d.getString("pubkey"))) {
+                continue;
+            }
             s += d.getString("_id") + " (" + d.getString("type") + ")\n";
         }
         String hash = Utils.getHash(s);

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -852,6 +852,13 @@ public enum Task implements Serializable {
                     if ("$".equals(pubkey)) {
                         continue;
                     }
+                    // 'toLoad' is an internal-only staging status (not yet servable). Excluding it here
+                    // — together with the matching exclusion in calculateTrustStateHash — keeps transient
+                    // 'toLoad' accounts out of the published snapshot, so an account enters the public
+                    // trust state exactly when it becomes loaded, never stuck at 'toLoad' (issue #119).
+                    if (toLoad.getValue().equals(a.getString("status"))) {
+                        continue;
+                    }
                     snapshotAccounts.add(new Document()
                             .append("pubkey", pubkey)
                             .append("agent", a.getString("agent"))

--- a/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
@@ -783,4 +783,40 @@ class RegistryDBTest {
         }
     }
 
+    @Test
+    void calculateTrustStateHashExcludesToLoadAccounts() {
+        RegistryDB.init();
+        try (ClientSession session = RegistryDB.getClient().startSession()) {
+            // Account A is loaded; account B (a leaf) is still in the 'toLoad' staging status.
+            RegistryDB.insert(session, "accounts_loading",
+                    new Document("agent", "agentA").append("pubkey", "pkA").append("status", EntryStatus.loaded.getValue()));
+            RegistryDB.insert(session, "accounts_loading",
+                    new Document("agent", "agentB").append("pubkey", "pkB").append("status", EntryStatus.toLoad.getValue()));
+
+            // One trust path per account.
+            RegistryDB.insert(session, "trustPaths_loading",
+                    new Document("_id", "pathA").append("type", "primary").append("agent", "agentA").append("pubkey", "pkA"));
+            RegistryDB.insert(session, "trustPaths_loading",
+                    new Document("_id", "pathB").append("type", "primary").append("agent", "agentB").append("pubkey", "pkB"));
+
+            String hashWithBToLoad = RegistryDB.calculateTrustStateHash(session);
+
+            // B's path must be excluded while B is 'toLoad': removing the path doc entirely yields the same hash.
+            RegistryDB.collection("trustPaths_loading").deleteOne(session, new Document("_id", "pathB"));
+            String hashWithBAbsent = RegistryDB.calculateTrustStateHash(session);
+            assertEquals(hashWithBAbsent, hashWithBToLoad,
+                    "A 'toLoad' account's trust path must not contribute to the hash");
+
+            // Restore B's path and promote B to 'loaded': it now enters the hash, so the hash changes.
+            RegistryDB.insert(session, "trustPaths_loading",
+                    new Document("_id", "pathB").append("type", "primary").append("agent", "agentB").append("pubkey", "pkB"));
+            RegistryDB.collection("accounts_loading").updateOne(session,
+                    new Document("agent", "agentB").append("pubkey", "pkB"),
+                    new Document("$set", new Document("status", EntryStatus.loaded.getValue())));
+            String hashWithBLoaded = RegistryDB.calculateTrustStateHash(session);
+            assertNotEquals(hashWithBToLoad, hashWithBLoaded,
+                    "Promoting a leaf account 'toLoad' -> 'loaded' must change the trust state hash (issue #119)");
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #119.

## Problem

A correctly approved-and-loaded **leaf** account (one with no outgoing trust edges — typical for bots/software agents) could stay published as `status: toLoad` in the consumer-facing trust-state snapshot **indefinitely**, while the live `accounts` collection / `list.json` already shows it as `loaded`.

Root cause: the snapshot-emission trigger is keyed on a hash computed **only over trust paths**, not account statuses (`RegistryDB.calculateTrustStateHash`). `LOAD_FULL` flips the live row `toLoad → loaded` between `UPDATE` cycles without changing any trust path, so for a leaf account that flip never moves the hash and never triggers a new snapshot. Effect: Nanodash and other snapshot consumers show the agent as not-approved even though it is.

## Fix

Treat `toLoad` as an internal-only staging status:

- `calculateTrustStateHash` now skips paths whose head account is currently `toLoad` (looked up from `accounts_loading`, which holds finalized statuses at hash time since `DETERMINE_UPDATES` runs first).
- The snapshot writer in `RELEASE_DATA` skips `toLoad` accounts.

An account then enters the public trust state **exactly when it becomes loaded** — crossing out of `toLoad` is itself a hash-membership change → emission, now as `loaded`. No mutable status field is hashed (so loads don't churn snapshots), and a permanently-unloadable account simply stays absent rather than freezing the whole trust state. `capped`/`skipped` are terminal non-`toLoad` states and still appear in snapshots as before.

This is the hash/snapshot-exclusion approach recommended in the issue, chosen over status-in-hash (churns, still publishes transient `toLoad`) and a load-barrier (risks a global freeze on one unloadable account).

## Notes

- One-time, expected: the first post-deploy cycle emits one snapshot as the hash baseline shifts.
- `calculateTrustStateHash` now also reads `accounts_loading` (documented inline).

## Test

New `RegistryDBTest.calculateTrustStateHashExcludesToLoadAccounts` proves both halves: a `toLoad` account's path contributes nothing to the hash, and promoting a leaf `toLoad → loaded` changes the hash (the membership change that now triggers the snapshot). Passes against a Testcontainers Mongo 7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)