### PR TITLE
chore(update): shorten trust-state update interval from 1h to 10min

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -913,9 +913,10 @@ public enum Task implements Serializable {
                 setServerStatus(s, ready);
             }
 
-            // Run update after 1h:
-            logger.debug("RELEASE_DATA complete; scheduling next UPDATE in 1h");
-            schedule(s, UPDATE.withDelay(60 * 60 * 1000));
+            // Run update 10min after this cycle finishes (the delay is measured from the end of the
+            // recompute, since this is the last task in the chain):
+            logger.debug("RELEASE_DATA complete; scheduling next UPDATE in 10min");
+            schedule(s, UPDATE.withDelay(10 * 60 * 1000));
         }
 
     },


### PR DESCRIPTION
Reduces the trust-state recompute interval from **1h to 10min** (`Task.java:918`).

## Semantics

The reschedule lives in `RELEASE_DATA`, the last task of the recompute chain, and `withDelay` stamps `not-before = now + delay` when that task runs. So the delay is measured **from the end of each cycle**, not its start — this change makes it "10 min after each update finishes."

## Why

Lower propagation latency for new approvals, new trust edges, and revocations landing in the published consumer-facing snapshot. Previously these waited up to ~1h.

## Why it's safe now

Tightening this interval is safe specifically because of the #119 fix (#120): `toLoad` accounts are excluded from the emission hash and snapshot. A cycle that fires while `LOAD_FULL` is still draining `toLoad` accounts simply omits the not-yet-loaded ones and picks them up the next cycle — bounded, no stale `toLoad`, no corruption. The cost is more frequent full recomputes and peer fetches.

A follow-up could make this configurable via a `REGISTRY_UPDATE_INTERVAL_SECONDS` env var; hard-coded for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)