### PR TITLE
fix: make the bootstrap setting immune to invalidation (#60)

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -221,6 +221,36 @@ public class RegistryDB {
     }
 
     /**
+     * Whether the given artifact code is a setting nanopub this instance was bootstrapped
+     * from, and therefore immune to invalidation (issue #60).
+     *
+     * <p>Checks both {@code original} and {@code current}. They are the same value today —
+     * {@link Task#LOAD_SETTING} writes both and only runs at {@code status == launching} —
+     * but the two are read separately elsewhere, so guarding both keeps the immunity intact
+     * if {@code current} ever starts tracking supersession.
+     *
+     * <p>Returns {@code false} when the setting has not been recorded yet, which is the case
+     * while {@code LOAD_SETTING} is still loading the setting nanopub itself. Nothing has been
+     * built at that point, so there are no trust edges to protect.
+     *
+     * @param mongoSession the MongoDB client session
+     * @param artifactCode the artifact code to test
+     * @return true if this is the bootstrap setting of this instance
+     */
+    static boolean isImmuneSetting(ClientSession mongoSession, String artifactCode) {
+        if (artifactCode == null) {
+            return false;
+        }
+        for (String key : new String[] { "original", "current" }) {
+            Object v = getValue(mongoSession, Collection.SETTING.toString(), key);
+            if (v != null && artifactCode.equals(v.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Retrieves the boolean value of an element with the given name from the specified collection.
      *
      * @param mongoSession the MongoDB client session
@@ -499,6 +529,36 @@ public class RegistryDB {
                     if (invalidatedAc == null) {
                         logger.warn("Nanopub {} references invalidated nanopub {} with an unresolvable artifact code; skipping", nanopub.getUri(), invalidatedId);
                         continue;  // This should never happen; checking here just to be sure
+                    }
+
+                    // The bootstrap setting is immune to invalidation (issue #60).
+                    //
+                    // Root endorsements are seeded with source = the setting's artifact code
+                    // (Task.INIT_COLLECTIONS), so the blanket trustEdges update below would
+                    // mark *every* root trust edge invalidated the moment anyone supersedes
+                    // the setting. EXPAND_TRUST_PATHS only follows edges with
+                    // invalidated == false, so the trust network collapses to the base agent
+                    // and never recovers: LOAD_SETTING runs only at status == launching, so
+                    // the registry keeps using the invalidated setting forever.
+                    //
+                    // That happened on 2026-08-05. A new setting was published at 05:39:06
+                    // whose only assertion change was TransitiveTrust -> IDEBT10, but whose
+                    // pubinfo carried npx:supersedes of the deployed setting — and
+                    // getInvalidatedNanopubIds counts npx:supersedes as invalidation. The
+                    // next iteration produced a trust state with 14 accounts instead of 777,
+                    // identically on all three registries, and every downstream consumer
+                    // (nanopub-query space state, Nanodash) went blank.
+                    //
+                    // Superseding a setting must be able to change the setting; it must not
+                    // be able to destroy the trust root that the running instance was
+                    // bootstrapped from.
+                    if (isImmuneSetting(mongoSession, invalidatedAc)) {
+                        logger.warn("Ignoring invalidation of the bootstrap setting {} by nanopub {}: "
+                                        + "the setting this instance was bootstrapped from is immune to "
+                                        + "invalidation (issue #60). Adopting a superseding setting requires "
+                                        + "deploying it as REGISTRY_SETTING_FILE and re-bootstrapping.",
+                                invalidatedAc, nanopub.getUri());
+                        continue;
                     }
 
                     // Add this nanopub also to all lists of invalidated nanopubs:

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -222,7 +222,14 @@ public class RegistryDB {
 
     /**
      * Whether the given artifact code is a setting nanopub this instance was bootstrapped
-     * from, and therefore immune to invalidation (issue #60).
+     * from, and whose trust edges therefore survive its invalidation (issue #60).
+     *
+     * <p>Scope: this does <em>not</em> make the setting un-invalidatable. The invalidation is
+     * still recorded in {@code invalidations} and the setting is still marked invalidated in
+     * {@code listEntries}, so it reads as superseded wherever it is listed. What is suppressed
+     * is only the consequence for the trust graph — the edges the setting is the {@code source}
+     * of are kept, so superseding a setting cannot sever the trust root of an instance already
+     * running on it.
      *
      * <p>Checks both {@code original} and {@code current}. They are the same value today —
      * {@link Task#LOAD_SETTING} writes both and only runs at {@code status == launching} —
@@ -531,7 +538,10 @@ public class RegistryDB {
                         continue;  // This should never happen; checking here just to be sure
                     }
 
-                    // The bootstrap setting is immune to invalidation (issue #60).
+                    // The bootstrap setting's trust edges are immune to invalidation (#60).
+                    // The invalidation itself is still recorded in full: the setting is
+                    // genuinely superseded and must read as invalidated everywhere it is
+                    // listed. Only its effect on the trust graph is suppressed.
                     //
                     // Root endorsements are seeded with source = the setting's artifact code
                     // (Task.INIT_COLLECTIONS), so the blanket trustEdges update below would
@@ -552,14 +562,11 @@ public class RegistryDB {
                     // Superseding a setting must be able to change the setting; it must not
                     // be able to destroy the trust root that the running instance was
                     // bootstrapped from.
-                    if (isImmuneSetting(mongoSession, invalidatedAc)) {
-                        logger.warn("Ignoring invalidation of the bootstrap setting {} by nanopub {}: "
-                                        + "the setting this instance was bootstrapped from is immune to "
-                                        + "invalidation (issue #60). Adopting a superseding setting requires "
-                                        + "deploying it as REGISTRY_SETTING_FILE and re-bootstrapping.",
-                                invalidatedAc, nanopub.getUri());
-                        continue;
-                    }
+                    // The invalidation itself is recorded normally below — the setting *is*
+                    // invalidated, and must show as such in the nanopub lists. Only the last
+                    // step, severing the trust edges it is the source of, is skipped.
+                    // Invalidating a setting says "this setting is superseded"; it must not
+                    // also mean "the instance running on it loses its trust root".
 
                     // Add this nanopub also to all lists of invalidated nanopubs:
                     logger.debug("Nanopub {} invalidates {}; updating list entries and trust edges", nanopub.getUri(), invalidatedId);
@@ -571,7 +578,17 @@ public class RegistryDB {
                     }
 
                     collection("listEntries").updateMany(mongoSession, new Document("np", invalidatedAc).append("pubkey", ph), new Document("$set", new Document("invalidated", true)));
-                    collection("trustEdges").updateMany(mongoSession, new Document("source", invalidatedAc), new Document("$set", new Document("invalidated", true)));
+
+                    if (isImmuneSetting(mongoSession, invalidatedAc)) {
+                        logger.warn("Nanopub {} invalidates the bootstrap setting {}: recorded as invalidated, "
+                                        + "but its trust edges are kept. The setting this instance was bootstrapped "
+                                        + "from is immune to invalidation (issue #60); adopting a superseding "
+                                        + "setting requires deploying it as REGISTRY_SETTING_FILE and "
+                                        + "re-bootstrapping.",
+                                nanopub.getUri(), invalidatedAc);
+                    } else {
+                        collection("trustEdges").updateMany(mongoSession, new Document("source", invalidatedAc), new Document("$set", new Document("invalidated", true)));
+                    }
                     logger.debug("Marked invalidated entries and trust edges for invalidated artifact {}", invalidatedAc);
                 }
             }

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -281,7 +281,16 @@ public enum Task implements Serializable {
                                 .append("source", sourceAc);
                         if (!has(s, "trustEdges", trustEdge)) {
                             boolean invalidated = has(s, "invalidations", new Document("invalidatedNp", sourceAc).append("invalidatingPubkey", sourcePubkey));
-                            if (invalidated) {
+                            if (invalidated && RegistryDB.isImmuneSetting(s, sourceAc)) {
+                                // The bootstrap setting stays recorded as invalidated, but edges
+                                // sourced from it survive (issue #60). Root endorsements use
+                                // sourcePubkey "$", so this lookup does not match them today —
+                                // guarded anyway so the rule holds wherever the edge comes from.
+                                logger.warn("Trust edge from {}/{} to {}/{} is sourced from the invalidated "
+                                                + "bootstrap setting {}; keeping it (issue #60)",
+                                        sourceAgent, sourcePubkey, agentId, agentPubkey, sourceAc);
+                                invalidated = false;
+                            } else if (invalidated) {
                                 logger.info("Trust edge from {}/{} to {}/{} is invalidated by source {}", sourceAgent, sourcePubkey, agentId, agentPubkey, sourceAc);
                             }
                             insert(s, "trustEdges", trustEdge.append("invalidated", invalidated));

--- a/src/test/java/com/knowledgepixels/registry/RegistryDBImmuneSettingTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryDBImmuneSettingTest.java
@@ -3,19 +3,36 @@ package com.knowledgepixels.registry;
 import com.knowledgepixels.registry.utils.FakeEnv;
 import com.knowledgepixels.registry.utils.TestUtils;
 import com.mongodb.client.ClientSession;
+import org.bson.Document;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubImpl;
+import org.nanopub.testsuite.NanopubTestSuite;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.mongodb.MongoDBContainer;
 
+import java.io.File;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
 
 /**
- * Issue #60 — the setting nanopub this instance was bootstrapped from must be immune to
- * invalidation.
+ * Issue #60 — invalidating the setting nanopub this instance was bootstrapped from must not
+ * sever its trust edges.
+ *
+ * <p>Scope, and it is deliberately narrow: the setting still gets invalidated normally. The
+ * {@code invalidations} record is written and its {@code listEntries} are marked, so it reads
+ * as superseded wherever it is listed. Only the consequence for the trust graph is suppressed.
  *
  * <p>Why it matters: {@code Task.INIT_COLLECTIONS} seeds every root endorsement with
  * {@code source = <setting artifact code>}, and {@code RegistryDB.loadNanopub} marks
@@ -91,6 +108,74 @@ class RegistryDBImmuneSettingTest {
 
             assertTrue(RegistryDB.isImmuneSetting(s, SETTING_AC), "current setting must be immune");
             assertTrue(RegistryDB.isImmuneSetting(s, OTHER_AC), "original setting must be immune");
+        }
+    }
+
+    /**
+     * The invalidation must still be recorded in full — the setting genuinely is superseded
+     * and has to read as invalidated wherever it is listed. Only its effect on the trust
+     * graph is suppressed.
+     */
+    @Test
+    void settingInvalidationIsRecordedButItsTrustEdgesSurvive() throws Exception {
+        try (ClientSession s = RegistryDB.getClient().startSession()) {
+            String settingAc = SETTING_AC;
+            RegistryDB.setValue(s, Collection.SETTING.toString(), "original", settingAc);
+            RegistryDB.setValue(s, Collection.SETTING.toString(), "current", settingAc);
+
+            // A root trust edge, as Task.INIT_COLLECTIONS seeds them.
+            RegistryDB.insert(s, "trustEdges", new Document("fromAgent", "$").append("fromPubkey", "$")
+                    .append("toAgent", "http://example.org/a").append("toPubkey", "pk")
+                    .append("source", settingAc).append("invalidated", false));
+
+            loadNanopubInvalidating(s, settingAc);
+
+            assertTrue(RegistryDB.has(s, "invalidations", new Document("invalidatedNp", settingAc)),
+                    "the invalidation itself must still be recorded");
+            assertFalse(trustEdgeInvalidated(s, settingAc),
+                    "trust edges sourced from the bootstrap setting must survive its invalidation");
+        }
+    }
+
+    @Test
+    void ordinaryInvalidationStillSeversItsTrustEdges() throws Exception {
+        try (ClientSession s = RegistryDB.getClient().startSession()) {
+            String settingAc = SETTING_AC;
+            String ordinaryAc = "RAlPfnKm8LTiHfLm2Uu7oHrJ5NCUOhqUvOTUuFVAr5hEg";
+            RegistryDB.setValue(s, Collection.SETTING.toString(), "original", settingAc);
+            RegistryDB.setValue(s, Collection.SETTING.toString(), "current", settingAc);
+
+            RegistryDB.insert(s, "trustEdges", new Document("fromAgent", "x").append("fromPubkey", "pk1")
+                    .append("toAgent", "http://example.org/b").append("toPubkey", "pk2")
+                    .append("source", ordinaryAc).append("invalidated", false));
+
+            loadNanopubInvalidating(s, ordinaryAc);
+
+            assertTrue(RegistryDB.has(s, "invalidations", new Document("invalidatedNp", ordinaryAc)));
+            assertTrue(trustEdgeInvalidated(s, ordinaryAc),
+                    "immunity must not leak: ordinary invalidation still severs its trust edges");
+        }
+    }
+
+    private static boolean trustEdgeInvalidated(ClientSession s, String sourceAc) {
+        Document e = RegistryDB.collection("trustEdges").find(s, new Document("source", sourceAc)).first();
+        assertNotNull(e, "test setup: the trust edge should exist");
+        return Boolean.TRUE.equals(e.getBoolean("invalidated"));
+    }
+
+    /**
+     * Loads a real nanopub while forcing it to invalidate {@code invalidatedAc}, so the
+     * invalidation branch of {@code loadNanopub} runs against a genuinely insertable nanopub.
+     */
+    private static void loadNanopubInvalidating(ClientSession s, String invalidatedAc) throws Exception {
+        File file = NanopubTestSuite.getLatest()
+                .getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
+        Nanopub np = new NanopubImpl(file);
+        IRI invalidated = SimpleValueFactory.getInstance()
+                .createIRI("http://purl.org/np/" + invalidatedAc);
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class, CALLS_REAL_METHODS)) {
+            utils.when(() -> Utils.getInvalidatedNanopubIds(np)).thenReturn(Set.of(invalidated));
+            RegistryDB.loadNanopub(s, np);
         }
     }
 

--- a/src/test/java/com/knowledgepixels/registry/RegistryDBImmuneSettingTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryDBImmuneSettingTest.java
@@ -1,0 +1,107 @@
+package com.knowledgepixels.registry;
+
+import com.knowledgepixels.registry.utils.FakeEnv;
+import com.knowledgepixels.registry.utils.TestUtils;
+import com.mongodb.client.ClientSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #60 — the setting nanopub this instance was bootstrapped from must be immune to
+ * invalidation.
+ *
+ * <p>Why it matters: {@code Task.INIT_COLLECTIONS} seeds every root endorsement with
+ * {@code source = <setting artifact code>}, and {@code RegistryDB.loadNanopub} marks
+ * <em>all</em> trust edges carrying an invalidated nanopub as their source:
+ * {@code updateMany(trustEdges, {source: invalidatedAc}, {$set: {invalidated: true}})} —
+ * with no pubkey restriction. {@code EXPAND_TRUST_PATHS} then follows only edges with
+ * {@code invalidated == false}, so a single {@code npx:supersedes} of the setting severs
+ * every root edge and the trust network collapses to the base agent.
+ *
+ * <p>It cannot recover on its own: {@code LOAD_SETTING} runs only at
+ * {@code status == launching}, so the instance keeps using the invalidated setting.
+ *
+ * <p>Observed in production 2026-08-05: a setting superseding the deployed one was
+ * published at 05:39:06 (its only assertion change was the trust-range algorithm), and the
+ * next iteration produced a trust state with 14 accounts instead of 777 — identically on
+ * three independent registries. Every iteration since logged
+ * "LOAD_CORE at depth 1 complete: 0 account(s) processed".
+ */
+@Testcontainers
+class RegistryDBImmuneSettingTest {
+
+    private static final String SETTING_AC = "RAb81iFm09N9D3-L5WoJCLNUjg7NBRs29MLgz-J2mXIWg";
+    private static final String OTHER_AC = "RAwUp0SmZZwQNOY1zbSPhR21aQoImiUyQrDlyXj5QYXmQ";
+
+    private FakeEnv fakeEnv;
+
+    @Container
+    private final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:7.0.0");
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException, IllegalAccessException {
+        fakeEnv = TestUtils.setupFakeEnv();
+        TestUtils.setupDBEnv(mongoDBContainer, "nanopubRegistry");
+        TestUtils.clearStaticFields(RegistryDB.class, "mongoClient", "mongoDB");
+        RegistryDB.init();
+    }
+
+    @AfterEach
+    void tearDown() {
+        fakeEnv.reset();
+    }
+
+    @Test
+    void bootstrapSettingIsImmune() {
+        try (ClientSession s = RegistryDB.getClient().startSession()) {
+            RegistryDB.setValue(s, Collection.SETTING.toString(), "original", SETTING_AC);
+            RegistryDB.setValue(s, Collection.SETTING.toString(), "current", SETTING_AC);
+
+            assertTrue(RegistryDB.isImmuneSetting(s, SETTING_AC),
+                    "the setting this instance was bootstrapped from must be immune");
+        }
+    }
+
+    @Test
+    void otherNanopubsAreNotImmune() {
+        try (ClientSession s = RegistryDB.getClient().startSession()) {
+            RegistryDB.setValue(s, Collection.SETTING.toString(), "original", SETTING_AC);
+            RegistryDB.setValue(s, Collection.SETTING.toString(), "current", SETTING_AC);
+
+            assertFalse(RegistryDB.isImmuneSetting(s, OTHER_AC),
+                    "immunity must not leak to ordinary nanopubs — normal retraction and "
+                            + "supersession must keep working");
+        }
+    }
+
+    @Test
+    void currentSettingIsAlsoImmuneWhenItDiffersFromOriginal() {
+        // current == original today, but they are stored and read separately. If current
+        // ever starts tracking supersession, the in-use setting must stay protected too.
+        try (ClientSession s = RegistryDB.getClient().startSession()) {
+            RegistryDB.setValue(s, Collection.SETTING.toString(), "original", OTHER_AC);
+            RegistryDB.setValue(s, Collection.SETTING.toString(), "current", SETTING_AC);
+
+            assertTrue(RegistryDB.isImmuneSetting(s, SETTING_AC), "current setting must be immune");
+            assertTrue(RegistryDB.isImmuneSetting(s, OTHER_AC), "original setting must be immune");
+        }
+    }
+
+    @Test
+    void noSettingRecordedYetMeansNoImmunity() {
+        // LOAD_SETTING loads the setting nanopub itself right after writing these values;
+        // before that there is nothing built, so there are no trust edges to protect.
+        try (ClientSession s = RegistryDB.getClient().startSession()) {
+            assertFalse(RegistryDB.isImmuneSetting(s, SETTING_AC));
+            assertFalse(RegistryDB.isImmuneSetting(s, null),
+                    "a null artifact code must not be treated as the setting");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #60.

## The failure

Superseding the setting nanopub severs the entire trust network.

`Task.INIT_COLLECTIONS` seeds every root endorsement with `source = <setting artifact code>` (`Task.java:191`). `RegistryDB.loadNanopub` then marks **all** trust edges carrying an invalidated nanopub as their source:

```java
collection("trustEdges").updateMany(mongoSession,
    new Document("source", invalidatedAc),
    new Document("$set", new Document("invalidated", true)));
```

— with no pubkey restriction. `EXPAND_TRUST_PATHS` follows only edges with `invalidated == false`, so a single `npx:supersedes` of the setting invalidates every root edge at once and the network collapses to the base agent.

It cannot recover on its own: `LOAD_SETTING` runs only at `status == launching` and pins both `original` and `current`, so the instance keeps using the invalidated setting indefinitely.

Worth noting `getInvalidatedNanopubIds` counts `npx:supersedes` (subject == self) as invalidation — so **publishing an updated setting is enough**, no explicit retraction required. That makes this considerably easier to trigger than #60's original wording suggests.

## Observed in production, 2026-08-05

A setting superseding the deployed one was published at 05:39:06. Its only assertion change was `hasTrustRangeAlgorithm TransitiveTrust → IDEBT10` — a field no code reads. The next trust iteration at 05:43:57 produced a trust state with **14 accounts instead of 777**, identically on `registry.knowledgepixels.com`, `registry.petapico.org` and `registry.nanodash.net` — three independent deployments with different `setupId`s.

Every iteration since:

```
Starting iteration at depth 0
LOAD_DECLARATIONS at depth 1 complete.
EXPAND_TRUST_PATHS at depth 1 complete.
LOAD_CORE at depth 1 complete: 0 account(s) processed
No new cores loaded; finishing iteration
```

Downstream, nanopub-query materialised the resulting 84-triple trust state faithfully (vs 7660 for the previous one), its space state went empty, and Nanodash's home page fell back to the misconfiguration notice.

## The fix

The setting is **still invalidated normally** — the `invalidations` record is written and its `listEntries` are marked, so it reads as superseded wherever it is listed. Only the last step, the blanket

```java
updateMany(trustEdges, {source: invalidatedAc}, {$set: {invalidated: true}})
```

is skipped for the bootstrap setting. Invalidating a setting says "this setting is superseded"; it must not also mean "the instance running on it loses its trust root".

Also guards the other place an edge gets that flag, at creation in `Task.LOAD_DECLARATIONS`. Root endorsements carry `sourcePubkey = "$"` so that lookup doesn't match them today, but the rule should hold wherever the edge comes from; the check only runs when the edge would otherwise be marked invalidated. Superseding a setting must be able to change the setting; it must not be able to destroy the trust root the running instance was bootstrapped from.

Adopting a superseding setting remains a deliberate act — deploy it as `REGISTRY_SETTING_FILE` and re-bootstrap — unchanged here.

Immunity is deliberately narrow: only the artifact codes recorded in the `SETTING` collection, so ordinary retraction and supersession are untouched.

## Tests

6 tests, full suite 184 green.

Two integration tests over the Testcontainers Mongo harness cover the distinction directly: a superseding nanopub against the bootstrap setting **records the invalidation but leaves its trust edges intact**, while an ordinary invalidation **still severs its own edges**. The first was confirmed to fail without the guard (`expected: <false> but was: <true>`); the second passes either way, which is what makes it a control rather than a restatement.

Four unit tests cover the predicate: bootstrap setting immune, ordinary nanopubs not, both `original` and `current` protected, unrecorded setting confers no immunity.

## Does not fix the current outage

Affected registries are already in the collapsed state and this change does not undo a recorded invalidation. Recovery still needs either a re-bootstrap, or clearing the stale `invalidations` / `trustEdges.invalidated` records for the setting artifact code. Worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)