### PR TITLE
fix: recover from a shutdown during a trust-state update (#50)

### DIFF
--- a/design.md
+++ b/design.md
@@ -112,7 +112,9 @@ Steps 2–4 can be skipped with `REGISTRY_ENABLE_TRUST_CALCULATION=false`, which
 5. `LOAD_FULL` → `RUN_OPTIONAL_LOAD` → `CHECK_NEW` — continuous cycle: load nanopubs for trusted accounts, then optionally load for non-approved pubkeys (one per cycle), then check peers for new nanopubs and discover new pubkeys, then loop back to `LOAD_FULL`. Optional loading can be disabled with `REGISTRY_ENABLE_OPTIONAL_LOAD=false`
 6. `UPDATE` (hourly) → `INIT_COLLECTIONS` — triggers a trust state recalculation (steps 2–4); the `LOAD_FULL` cycle (step 5) continues running during updates
 
-See [Task.java](src/main/java/com/knowledgepixels/registry/Task.java).
+A task is removed from the queue only after it has run, and its writes are not atomic with that removal, so a shutdown mid-task leaves the task queued and its writes half-applied. On startup, a trust state cycle (steps 2–4) interrupted this way is therefore not resumed but restarted: the queued cycle tasks are dropped and `INIT_COLLECTIONS` is scheduled afresh, which discards the `_loading` collections and rebuilds them. Only a pending `RELEASE_DATA` is kept and left to finish, since the cycle is complete by then and that task is idempotent.
+
+See [Task.java](src/main/java/com/knowledgepixels/registry/Task.java) (`recoverInterruptedCycle`).
 
 
 ## Updating from peers
@@ -239,7 +241,7 @@ Field type legend: primary# / unique* / combined-unique** / indexed^ (all with p
       { notBefore^:1710672000000, action^:CHECK_NEW }
       { notBefore^:1710672000100, action^:LOAD_FULL }
 
-During trust state computation, intermediate `_loading` collections (`endorsements_loading`, `accounts_loading`, `agents_loading`, `trustPaths_loading`) are used and then renamed to replace the live collections in `RELEASE_DATA`.
+During trust state computation, intermediate `_loading` collections (`endorsements_loading`, `accounts_loading`, `agents_loading`, `trustPaths_loading`) are used and then renamed to replace the live collections in `RELEASE_DATA`. They are always built from scratch: `INIT_COLLECTIONS` drops whatever is still there before it starts inserting, so a cycle left half-built by a shutdown is discarded rather than added to.
 
 See also [RegistryDB.java](src/main/java/com/knowledgepixels/registry/RegistryDB.java).
 

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -31,7 +31,10 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 
 import static com.mongodb.client.model.Indexes.ascending;
@@ -112,6 +115,54 @@ public class RegistryDB {
         boolean initialized = getValue(mongoSession, Collection.SERVER_INFO.toString(), "setupId") != null;
         logger.debug("isInitialized check for database '{}': {}", REGISTRY_DB_NAME, initialized);
         return initialized;
+    }
+
+    /**
+     * The staging collections that a trust-state cycle rebuilds from scratch, each mapped to the
+     * live collection it is promoted to when the cycle completes.
+     *
+     * @see #promoteLoadingCollections()
+     * @see #dropLoadingCollections()
+     */
+    private static final Map<String, String> LOADING_COLLECTIONS = createLoadingCollectionsMap();
+
+    private static Map<String, String> createLoadingCollectionsMap() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("accounts_loading", Collection.ACCOUNTS.toString());
+        map.put("trustPaths_loading", "trustPaths");
+        map.put("agents_loading", Collection.AGENTS.toString());
+        map.put("endorsements_loading", "endorsements");
+        return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Discards all staging collections of a trust-state cycle.
+     *
+     * <p>Designed as an idempotent operation: in a healthy run the collections do not exist at this
+     * point, as {@link #promoteLoadingCollections()} renamed them away at the end of the previous
+     * cycle. Anything left behind is a half-built cycle from an interrupted run, which must be
+     * discarded rather than added to: the cycle tasks insert into these collections unconditionally
+     * and would otherwise fail on duplicate keys forever (issue #50).
+     */
+    public static void dropLoadingCollections() {
+        for (String loadingCollectionName : LOADING_COLLECTIONS.keySet()) {
+            if (hasCollection(loadingCollectionName)) {
+                logger.info("Discarding leftover staging collection '{}'", loadingCollectionName);
+                collection(loadingCollectionName).drop();
+            }
+        }
+    }
+
+    /**
+     * Promotes the staging collections of a completed trust-state cycle to their live names,
+     * replacing the previous cycle's data.
+     *
+     * <p>Designed as an idempotent operation, since {@link #rename} is.
+     */
+    public static void promoteLoadingCollections() {
+        for (Map.Entry<String, String> entry : LOADING_COLLECTIONS.entrySet()) {
+            rename(entry.getKey(), entry.getValue());
+        }
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -31,6 +31,7 @@ import static com.knowledgepixels.registry.NanopubLoader.*;
 import static com.knowledgepixels.registry.RegistryDB.*;
 import static com.knowledgepixels.registry.ServerStatus.*;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Sorts.*;
 
 public enum Task implements Serializable {
@@ -141,6 +142,12 @@ public enum Task implements Serializable {
                 logger.error("INIT_COLLECTIONS aborted: expected server status 'coreLoading' or 'updating' but found '{}'", status);
                 throw new IllegalTaskStatusException("Illegal status for this task: " + status);
             }
+
+            // A cycle always builds its staging collections from scratch, so anything still there
+            // is a half-built cycle left by an interrupted run and has to go before we start
+            // inserting (issue #50). Done outside the transaction, as dropping a collection is a
+            // DDL operation; it is idempotent, so a retry of this task is unaffected.
+            dropLoadingCollections();
 
             IndexInitializer.initLoadingCollections(s);
 
@@ -826,10 +833,7 @@ public enum Task implements Serializable {
 
             // Renaming collections is run outside of a transaction, but is idempotent operation, so can safely be retried if task fails:
             logger.debug("Renaming loading collections into live collections");
-            rename("accounts_loading", Collection.ACCOUNTS.toString());
-            rename("trustPaths_loading", "trustPaths");
-            rename("agents_loading", Collection.AGENTS.toString());
-            rename("endorsements_loading", "endorsements");
+            promoteLoadingCollections();
 
             if (previousTrustStateHash == null || !previousTrustStateHash.equals(newTrustStateHash)) {
                 logger.info("Trust state changed ({} -> {}); recording new state and snapshot", previousTrustStateHash, newTrustStateHash);
@@ -1296,6 +1300,17 @@ public enum Task implements Serializable {
 
     private static MongoCollection<Document> tasksCollection = collection(Collection.TASKS.toString());
 
+    /**
+     * The tasks that make up one trust-state cycle, from building the staging collections to
+     * promoting them to their live names.
+     *
+     * @see #recoverInterruptedCycle
+     */
+    private static final Set<Task> TRUST_CYCLE_TASKS = EnumSet.of(
+            INIT_COLLECTIONS, LOAD_DECLARATIONS, EXPAND_TRUST_PATHS, LOAD_CORE, FINISH_ITERATION,
+            CALCULATE_TRUST_SCORES, AGGREGATE_AGENTS, ASSIGN_PUBKEYS, DETERMINE_UPDATES,
+            FINALIZE_TRUST_STATE, RELEASE_DATA);
+
     private static volatile String currentTaskName;
     private static volatile long currentTaskStartTime;
 
@@ -1308,12 +1323,66 @@ public enum Task implements Serializable {
     }
 
     /**
+     * Restarts a trust-state cycle that a shutdown interrupted, so the registry can recover on its
+     * own (issue #50).
+     *
+     * <p>Task writes are not atomic with the removal of the task from the queue, so a task that was
+     * running when the process died is picked up again on restart and re-executes writes it already
+     * performed. For most of the cycle that is harmless — the tasks pick their work by entry status
+     * — but the unconditional inserts in {@link #INIT_COLLECTIONS} then fail on duplicate keys, and
+     * that task retries forever without ever getting past them. A crash can also leave both a task
+     * and the successor it scheduled in the queue, making the rest of the cycle run twice.
+     *
+     * <p>Rather than resuming a half-built cycle, we therefore restart it: the queued cycle tasks
+     * are dropped and a fresh {@link #INIT_COLLECTIONS} is scheduled, which discards the staging
+     * collections and rebuilds them. This costs one recomputation and nothing else — the staging
+     * collections only become live at the end of the cycle, so the trust state currently served
+     * (status {@code updating}) is untouched.
+     *
+     * <p>The exception is a queued {@link #RELEASE_DATA}: the cycle is then complete and that task
+     * is idempotent by design, so it is kept and left to finish rather than recomputed. Its
+     * siblings are still dropped, so a duplicate predecessor cannot run the cycle a second time.
+     *
+     * @param mongoSession the MongoDB client session
+     */
+    static void recoverInterruptedCycle(ClientSession mongoSession) {
+        Object statusValue = getValue(mongoSession, Collection.SERVER_INFO.toString(), "status");
+        if (statusValue == null) {
+            return;
+        }
+        ServerStatus status = ServerStatus.valueOf(statusValue.toString());
+        if (status != coreLoading && status != updating) {
+            // No cycle was in progress; if one is due, a queued UPDATE starts it from scratch.
+            logger.debug("Server status is {}; no interrupted trust-state cycle to recover", status);
+            return;
+        }
+
+        boolean releasePending = tasksCollection.find(mongoSession, eq("action", RELEASE_DATA.name())).first() != null;
+        List<String> obsolete = TRUST_CYCLE_TASKS.stream()
+                .filter(task -> !releasePending || task != RELEASE_DATA)
+                .map(Task::name)
+                .toList();
+        long removed = tasksCollection.deleteMany(mongoSession, in("action", obsolete)).getDeletedCount();
+
+        if (releasePending) {
+            logger.info("Recovering trust-state cycle interrupted in status {}: dropped {} queued task(s), letting the pending {} finish the cycle",
+                    status, removed, RELEASE_DATA.name());
+        } else {
+            logger.info("Recovering trust-state cycle interrupted in status {}: dropped {} queued task(s), restarting the cycle at {}",
+                    status, removed, INIT_COLLECTIONS.name());
+            schedule(mongoSession, INIT_COLLECTIONS);
+        }
+    }
+
+    /**
      * The super important base entry point!
      */
     static void runTasks() {
         try (ClientSession s = RegistryDB.getClient().startSession()) {
             if (!RegistryDB.isInitialized(s)) {
                 schedule(s, INIT_DB); // does not yet execute, only schedules
+            } else {
+                recoverInterruptedCycle(s);
             }
 
             logger.info("Task runner started");

--- a/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
@@ -141,6 +141,56 @@ class RegistryDBTest {
     }
 
     @Test
+    void dropLoadingCollections() {
+        RegistryDB.init();
+
+        ClientSession session = RegistryDB.getClient().startSession();
+        RegistryDB.insert(session, "trustPaths_loading", new Document("_id", "$"));
+        RegistryDB.insert(session, "accounts_loading", new Document("_id", "testKey"));
+        RegistryDB.insert(session, "trustPaths", new Document("_id", "$"));
+
+        RegistryDB.dropLoadingCollections();
+
+        assertFalse(RegistryDB.hasCollection("trustPaths_loading"));
+        assertFalse(RegistryDB.hasCollection("accounts_loading"));
+        // The live collections of the previous cycle stay in place and keep being served:
+        assertTrue(RegistryDB.hasCollection("trustPaths"));
+    }
+
+    @Test
+    void dropLoadingCollectionsWhenNoneExist() {
+        RegistryDB.init();
+
+        assertFalse(RegistryDB.hasCollection("trustPaths_loading"));
+
+        RegistryDB.dropLoadingCollections();
+        assertFalse(RegistryDB.hasCollection("trustPaths_loading"));
+    }
+
+    @Test
+    void promoteLoadingCollections() {
+        RegistryDB.init();
+
+        ClientSession session = RegistryDB.getClient().startSession();
+        RegistryDB.insert(session, "trustPaths", new Document("_id", "outdated"));
+        RegistryDB.insert(session, "trustPaths_loading", new Document("_id", "$"));
+        RegistryDB.insert(session, "accounts_loading", new Document("_id", "testKey"));
+        RegistryDB.insert(session, "agents_loading", new Document("_id", "testKey"));
+        RegistryDB.insert(session, "endorsements_loading", new Document("_id", "testKey"));
+
+        RegistryDB.promoteLoadingCollections();
+
+        for (String loadingCollectionName : new String[]{"trustPaths_loading", "accounts_loading", "agents_loading", "endorsements_loading"}) {
+            assertFalse(RegistryDB.hasCollection(loadingCollectionName));
+        }
+        for (String liveCollectionName : new String[]{"trustPaths", "accounts", "agents", "endorsements"}) {
+            assertTrue(RegistryDB.hasCollection(liveCollectionName));
+        }
+        assertNotNull(RegistryDB.collection("trustPaths").find(session, new Document("_id", "$")).first());
+        assertNull(RegistryDB.collection("trustPaths").find(session, new Document("_id", "outdated")).first());
+    }
+
+    @Test
     void getPubkey() throws MalformedNanopubException, IOException {
         File file = NanopubTestSuite.getLatest().getByArtifactCode("RArZHDDWzq3MYkBQ5FyWrhJJnfVYuE6Y9BmipJQVLLjNY").getFirst().toFile();
         Nanopub nanopub = new NanopubImpl(file);

--- a/src/test/java/com/knowledgepixels/registry/TaskTest.java
+++ b/src/test/java/com/knowledgepixels/registry/TaskTest.java
@@ -130,4 +130,87 @@ class TaskTest {
         assertTrue(loadFullCount >= 2);
     }
 
+    @Test
+    void recoverInterruptedCycleRestartsTheCycle() throws Exception {
+        ClientSession mongoSession = startCycleInterruptedAs(ServerStatus.updating);
+        // A cycle interrupted midway, plus a duplicate successor left behind by the crash:
+        queueTasks(mongoSession, Task.LOAD_DECLARATIONS, Task.EXPAND_TRUST_PATHS, Task.LOAD_FULL);
+
+        Task.recoverInterruptedCycle(mongoSession);
+
+        List<String> actions = queuedActions(mongoSession);
+        assertEquals(2, actions.size());
+        assertTrue(actions.contains(Task.INIT_COLLECTIONS.name()));
+        // Tasks outside the trust-state cycle keep their place in the queue:
+        assertTrue(actions.contains(Task.LOAD_FULL.name()));
+    }
+
+    @Test
+    void recoverInterruptedCycleDuringCoreLoading() throws Exception {
+        ClientSession mongoSession = startCycleInterruptedAs(ServerStatus.coreLoading);
+        queueTasks(mongoSession, Task.INIT_COLLECTIONS);
+
+        Task.recoverInterruptedCycle(mongoSession);
+
+        // The re-queued INIT_COLLECTIONS is the recovery's own, not the interrupted one:
+        assertEquals(List.of(Task.INIT_COLLECTIONS.name()), queuedActions(mongoSession));
+    }
+
+    @Test
+    void recoverInterruptedCycleKeepsPendingReleaseData() throws Exception {
+        ClientSession mongoSession = startCycleInterruptedAs(ServerStatus.updating);
+        // The cycle is complete; RELEASE_DATA is idempotent and finishes it:
+        queueTasks(mongoSession, Task.FINALIZE_TRUST_STATE, Task.RELEASE_DATA);
+
+        Task.recoverInterruptedCycle(mongoSession);
+
+        assertEquals(List.of(Task.RELEASE_DATA.name()), queuedActions(mongoSession));
+    }
+
+    @Test
+    void recoverInterruptedCycleWhenNoCycleWasRunning() throws Exception {
+        ClientSession mongoSession = startCycleInterruptedAs(ServerStatus.ready);
+        queueTasks(mongoSession, Task.UPDATE);
+
+        Task.recoverInterruptedCycle(mongoSession);
+
+        assertEquals(List.of(Task.UPDATE.name()), queuedActions(mongoSession));
+    }
+
+    @Test
+    void recoverInterruptedCycleOnUninitializedDatabase() {
+        ClientSession mongoSession = RegistryDB.getClient().startSession();
+
+        Task.recoverInterruptedCycle(mongoSession);
+
+        assertEquals(List.of(), queuedActions(mongoSession));
+    }
+
+    /**
+     * Brings the DB into the state a shutdown during a trust-state cycle leaves behind: the given
+     * server status, and an empty task queue for the test to fill with the tasks that were pending.
+     */
+    private ClientSession startCycleInterruptedAs(ServerStatus status) throws Exception {
+        Task.runTask(Task.INIT_DB, Task.INIT_DB.asDocument());
+        ClientSession mongoSession = RegistryDB.getClient().startSession();
+        collection(Collection.TASKS.toString()).deleteMany(mongoSession, new Document());
+        RegistryDB.setValue(mongoSession, Collection.SERVER_INFO.toString(), "status", status.toString());
+        return mongoSession;
+    }
+
+    private void queueTasks(ClientSession mongoSession, Task... tasks) {
+        for (Task task : tasks) {
+            collection(Collection.TASKS.toString()).insertOne(mongoSession, task.asDocument());
+        }
+    }
+
+    private List<String> queuedActions(ClientSession mongoSession) {
+        return collection(Collection.TASKS.toString())
+                .find(mongoSession)
+                .into(new ArrayList<Document>())
+                .stream()
+                .map(d -> d.getString("action"))
+                .toList();
+    }
+
 }


### PR DESCRIPTION
Fixes #50.

## The problem

A task is removed from the queue only after it has run, and its writes are not atomic with that removal (`runTask` opens its own session, so the transaction wrapper in `runTasks` does not cover them). A shutdown mid-task therefore leaves the task queued and its writes half-applied.

`INIT_COLLECTIONS` is the task that breaks on this. It inserts the root trust path `{_id: "$"}` into `trustPaths_loading` and then fetches the agent intro collection over the network — a wide window in which to be killed. On restart the task is picked up again, re-runs the unconditional insert, and fails with `E11000 duplicate key`. Nothing ever clears the staging collections, so it retries every second forever and the registry stays stuck in `coreLoading`/`updating` until the database is repaired by hand.

## The fix

**Drop.** `INIT_COLLECTIONS` now discards the staging collections before it starts inserting. In a healthy run this is a no-op — `RELEASE_DATA` renamed them away at the end of the previous cycle — so the only thing it ever removes is a half-built cycle from a crash, which is exactly what has to go.

The four `_loading` → live names now live in one map in `RegistryDB`, read by both `dropLoadingCollections()` and `promoteLoadingCollections()`; `RELEASE_DATA`'s four hardcoded `rename` calls became the latter, so the two cannot drift apart.

**Startup recovery.** New `Task.recoverInterruptedCycle`, called from `runTasks()` when the DB is already initialized. If the status is `coreLoading` or `updating`, a cycle was interrupted: the queued cycle tasks are dropped and a fresh `INIT_COLLECTIONS` is scheduled. Tasks outside the cycle (`LOAD_FULL`, `CHECK_NEW`, …) are left alone. This also covers the crash-between-`schedule`-and-`delete` case, where a task and the successor it scheduled both remain queued and the rest of the cycle would run twice.

One deliberate exception: a queued `RELEASE_DATA` is kept and left to finish rather than purged. The cycle is complete by then and that task is idempotent by design, so restarting would throw away a finished computation — and purging it while scheduling `INIT_COLLECTIONS` would be worse than the original bug, since `RELEASE_DATA` runs first, sets the status to `ready`, and `INIT_COLLECTIONS` would then fail its status guard forever.

Restarting a cycle costs one recomputation and nothing else: staging data only becomes live at the end of a cycle, so the trust state currently being served is untouched.

## Testing

8 new tests — 5 in `TaskTest` (restart, `coreLoading`, the `RELEASE_DATA` exception, non-cycle statuses, uninitialized DB) and 3 in `RegistryDBTest` (drop, drop when absent, promote). Full suite green: 193 tests, 0 failures.

## Out of scope

- The session bug above (`runAsTransaction` is effectively inert for every task) deserves its own issue. This fix works regardless of whether it is addressed.
- `design.md` still says `UPDATE` is hourly; it has been 10min since 2456050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)