### PR TITLE
fix: hold back the bootstrap trust state until the initial full load completes

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -114,7 +114,7 @@ public enum Task implements Serializable {
             // potentially currently hardcoded in the nanopub lib
             setValue(s, Collection.SETTING.toString(), "bootstrap-services", bootstrapServices);
 
-            boolean performFullLoad = !"false".equals(System.getenv("REGISTRY_PERFORM_FULL_LOAD"));
+            boolean performFullLoad = !"false".equals(Utils.getEnv("REGISTRY_PERFORM_FULL_LOAD", null));
             if (performFullLoad) {
                 logger.debug("REGISTRY_PERFORM_FULL_LOAD not disabled; scheduling LOAD_FULL task");
                 schedule(s, LOAD_FULL);
@@ -947,6 +947,10 @@ public enum Task implements Serializable {
          * snapshot, the retention pruning and the server status transition. Transactional — every
          * write here is an ordinary document write on collections {@link #RELEASE_DATA} has
          * already renamed into place.
+         *
+         * <p>The very first state of a fresh registry is held back: nothing is recorded until a
+         * cycle finds the initial full load complete, so consumers never see the near-empty
+         * bootstrap state (see below).
          */
         public void run(ClientSession s, Document taskDoc) {
             ServerStatus status = getServerStatus(s);
@@ -954,8 +958,24 @@ public enum Task implements Serializable {
 
             String newTrustStateHash = taskDoc.get("newTrustStateHash").toString();
             String previousTrustStateHash = taskDoc.getString("previousTrustStateHash");  // may be null
+            String storedTrustStateHash = (String) getValue(s, Collection.SERVER_INFO.toString(), "trustStateHash");  // null until the first publication
 
-            if (previousTrustStateHash == null || !previousTrustStateHash.equals(newTrustStateHash)) {
+            if (storedTrustStateHash == null
+                    && !"false".equals(Utils.getEnv("REGISTRY_PERFORM_FULL_LOAD", null))
+                    && has(s, Collection.ACCOUNTS.toString(), new DbEntryWrapper(toLoad).getDocument())) {
+                // Bootstrap: nothing has ever been published and the just-released accounts are
+                // still waiting for their initial full load, so the computed state is the
+                // near-empty bootstrap one — every account still 'toLoad' is excluded from the
+                // hash and the snapshot (issue #119, calculateTrustStateHash). Publishing it would
+                // hand consumers a trust state containing essentially nobody, replaced as soon as
+                // loading finishes without any change in the network. Hold off instead until a
+                // cycle finds the initial load complete. Checked against the database rather than
+                // the server status because the initial load can span several update cycles, and
+                // because a re-run of the non-transactional RELEASE_DATA enqueues this task twice.
+                // Once something has been published, 'toLoad' accounts are normal between-cycles
+                // state (#119) and must not suppress publication.
+                logger.info("Initial full load not complete yet; not publishing bootstrap trust state {}", newTrustStateHash);
+            } else if (previousTrustStateHash == null || !previousTrustStateHash.equals(newTrustStateHash)) {
                 logger.info("Trust state changed ({} -> {}); recording new state and snapshot", previousTrustStateHash, newTrustStateHash);
                 // Bump the counter and record the hash only once per distinct trust state. This
                 // task is transactional, so it cannot half-apply — but RELEASE_DATA is not, and an
@@ -963,7 +983,6 @@ public enum Task implements Serializable {
                 // check has to be against the stored hash rather than against
                 // previousTrustStateHash from the task document, which still holds the value from
                 // before the first run and would let the counter drift on every duplicate.
-                String storedTrustStateHash = (String) getValue(s, Collection.SERVER_INFO.toString(), "trustStateHash");
                 if (newTrustStateHash.equals(storedTrustStateHash)) {
                     logger.info("Trust state {} was already recorded by an earlier run of this task; not bumping the counter again", newTrustStateHash);
                 } else {
@@ -1079,7 +1098,7 @@ public enum Task implements Serializable {
         public void run(ClientSession s, Document taskDoc) {
             logger.debug("LOAD_FULL invoked; taskDoc={}", taskDoc);
 
-            if ("false".equals(System.getenv("REGISTRY_PERFORM_FULL_LOAD"))) {
+            if ("false".equals(Utils.getEnv("REGISTRY_PERFORM_FULL_LOAD", null))) {
                 logger.info("REGISTRY_PERFORM_FULL_LOAD=false; skipping full load");
                 return;
             }

--- a/src/test/java/com/knowledgepixels/registry/TaskTest.java
+++ b/src/test/java/com/knowledgepixels/registry/TaskTest.java
@@ -218,6 +218,51 @@ class TaskTest {
         assertDoesNotThrow(() -> Task.runTask(mongoSession, Task.INIT_COLLECTIONS, Task.INIT_COLLECTIONS.asDocument()));
     }
 
+    /**
+     * A fresh registry's first computed trust state is the near-empty bootstrap one: every account
+     * is still 'toLoad' and therefore excluded from the hash and the snapshot (issue #119).
+     * PUBLISH_TRUST_STATE holds that state back — nothing is recorded until a cycle finds the
+     * initial full load complete — so consumers never see a trust state containing essentially
+     * nobody, replaced right afterwards without any change in the network.
+     */
+    @Test
+    void publishTrustStateHoldsBackBootstrapState() throws Exception {
+        ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.INIT_DB, Task.INIT_DB.asDocument());
+        Task.runTask(mongoSession, Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
+
+        TestUtils.copyResourceToDataDir("setting.trig");
+        fakeEnv.addVariable("REGISTRY_SETTING_FILE", TestUtils.getDataDir().resolve("setting.trig").toString()).build();
+        Task.runTask(mongoSession, Task.LOAD_SETTING, Task.LOAD_SETTING.asDocument());
+
+        long counterBefore = trustStateCounter(mongoSession);
+
+        // As after RELEASE_DATA on a fresh instance: the released accounts still await the full load
+        RegistryDB.insert(mongoSession, Collection.ACCOUNTS.toString(),
+                new Document("agent", "testAgent").append("pubkey", "testPubkey").append("status", EntryStatus.toLoad.getValue()));
+
+        Task.runTask(mongoSession, Task.PUBLISH_TRUST_STATE,
+                Task.PUBLISH_TRUST_STATE.asDocument().append("newTrustStateHash", "bootstrapHash"));
+
+        assertNull(getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateHash"), "the bootstrap state must not be recorded");
+        assertEquals(0, collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).countDocuments(mongoSession));
+        assertEquals(counterBefore, trustStateCounter(mongoSession), "the bootstrap state must not bump the trust state counter");
+        assertEquals(ServerStatus.coreReady.toString(), getValue(mongoSession, Collection.SERVER_INFO.toString(), "status"),
+                "holding back the state must not hold back the status transition");
+
+        // The initial full load completes, and the next cycle publishes its state as the first one
+        collection(Collection.ACCOUNTS.toString()).updateMany(mongoSession, new Document(),
+                new Document("$set", new Document("status", EntryStatus.loaded.getValue())));
+
+        Task.runTask(mongoSession, Task.PUBLISH_TRUST_STATE,
+                Task.PUBLISH_TRUST_STATE.asDocument().append("newTrustStateHash", "fullHash"));
+
+        assertEquals("fullHash", getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateHash"));
+        assertEquals(counterBefore + 1, trustStateCounter(mongoSession));
+        assertNotNull(collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).find(mongoSession, new Document("_id", "fullHash")).first(),
+                "the first published snapshot should be the post-load state");
+    }
+
     private static long trustStateCounter(ClientSession mongoSession) {
         return ((Number) getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateCounter")).longValue();
     }


### PR DESCRIPTION
## Problem

Every fresh registry starts at trust state `c6657f5e9e` and then switches to `c96bfc42db` without any change in the network.

On the first trust cycle, `DETERMINE_UPDATES` marks every approved account `toLoad` (nothing is loaded yet), and since #119 the hash and snapshot exclude `toLoad` accounts. So the first published snapshot is the near-empty bootstrap state — containing essentially nobody — and it is replaced on the next cycle once `LOAD_FULL` has flipped the accounts to `loaded`. Consumers mirroring `/trust-state` briefly see (and may act on) that spurious state.

## Fix

`PUBLISH_TRUST_STATE` now records nothing (no counter bump, no hash, no snapshot) while all three hold:

- no trust state has ever been published (`trustStateHash` in `serverInfo` is null),
- full loading is enabled (`REGISTRY_PERFORM_FULL_LOAD` is not `"false"`),
- the just-released accounts still contain `toLoad` entries.

The first published snapshot is therefore the post-load state. The guard reads the database rather than the server status, so it also holds back intermediate partial states when the initial load spans several 10-minute cycles, and it is idempotent across the duplicate enqueue from a re-run of the non-transactional `RELEASE_DATA`. The `coreLoading → coreReady` status transition and `UPDATE` scheduling are unaffected. Once anything has been published, `toLoad` accounts never suppress publication, so the #119 behavior (account promotion → new hash → new snapshot) is unchanged.

## Env read consistency

The guard makes `REGISTRY_PERFORM_FULL_LOAD` load-bearing in a new place, so this PR also converts the two existing `System.getenv` reads of that flag (`LOAD_SETTING`, `LOAD_FULL`) to `Utils.getEnv`. This is not a tidy-up — the two reads must agree for the fix to be safe: the hold-back's only exit is `LOAD_FULL` draining the `toLoad` accounts, and `LOAD_FULL`'s disabled-mode early return coincides with the guard disabling itself precisely because both reads go through the same reader. With split readers (as under the test `FakeEnv` before this change), a registry could run with the hold-back on and the load loop off — held back forever, with nothing to catch it. Together with `REGISTRY_ENABLE_TRUST_CALCULATION` (converted in #128's branch), that makes four converted reads; `REGISTRY_TEST_INSTANCE`, `REGISTRY_COVERAGE_TYPES`, `REGISTRY_COVERAGE_AGENTS`, `REGISTRY_ENABLE_OPTIONAL_LOAD`, and `REGISTRY_PRIORITIZE_ALL_PUBKEYS` are deliberately left on `System.getenv` for now — the mix is intentional, not accidental.

## Testing

New `publishTrustStateHoldsBackBootstrapState` verifies that a first publish with a `toLoad` account records nothing while still transitioning to `coreReady`, and that the next cycle after loading publishes normally. `mvn test -Dtest=TaskTest`: 7/7 green on this branch.

## Stacking

Based on `fix/128-task-transactions` (PR #130), which introduced the `RELEASE_DATA`/`PUBLISH_TRUST_STATE` split this guard lives in. **Update:** this PR has been merged into that branch (fb2cd42), so its content now ships via #130 — no separate merge or retarget needed. The guard was additionally verified against #127's `recoverInterruptedCycle` (merged into the branch from main): a restart mid-bootstrap re-runs the kept `PUBLISH_TRUST_STATE` tail task and skips again on the same DB state, and recovery cannot drop the `LOAD_FULL`/`RUN_OPTIONAL_LOAD`/`CHECK_NEW` loop that ends the hold-back, since those tasks are not part of `TRUST_CYCLE_TASKS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

