### PR TITLE
fix: make task transactions real, and split the tasks that cannot use them

### DIFF
--- a/design.md
+++ b/design.md
@@ -103,14 +103,19 @@ See [MainVerticle.java](src/main/java/com/knowledgepixels/registry/MainVerticle.
 
 Tasks are scheduled and executed sequentially from a `tasks` collection. The main flow:
 
-1. `INIT_DB` → `LOAD_CONFIG` → `LOAD_SETTING` → `INIT_COLLECTIONS` — bootstrap the registry
+1. `INIT_DB` → `LOAD_CONFIG` → `LOAD_SETTING` → `INIT_COLLECTIONS` → `SEED_TRUST_STATE` — bootstrap the registry
 2. `LOAD_DECLARATIONS` → `EXPAND_TRUST_PATHS` → `LOAD_CORE` — iteratively load core nanopubs and build the trust network
 3. `FINISH_ITERATION` — repeats step 2 until no more changes
-4. `CALCULATE_TRUST_SCORES` → `AGGREGATE_AGENTS` → `ASSIGN_PUBKEYS` → `DETERMINE_UPDATES` → `FINALIZE_TRUST_STATE` → `RELEASE_DATA` — compute trust scores and quotas, swap in new data
+4. `CALCULATE_TRUST_SCORES` → `AGGREGATE_AGENTS` → `ASSIGN_PUBKEYS` → `DETERMINE_UPDATES` → `FINALIZE_TRUST_STATE` → `RELEASE_DATA` → `PUBLISH_TRUST_STATE` — compute trust scores and quotas, swap in new data
 
-Steps 2–4 can be skipped with `REGISTRY_ENABLE_TRUST_CALCULATION=false`, which makes `INIT_COLLECTIONS` jump straight to `FINALIZE_TRUST_STATE`. Useful when only explicit `REGISTRY_COVERAGE_AGENTS` pubkeys are needed.
+Steps 2–4 can be skipped with `REGISTRY_ENABLE_TRUST_CALCULATION=false`, which makes `SEED_TRUST_STATE` jump straight to `FINALIZE_TRUST_STATE`. Useful when only explicit `REGISTRY_COVERAGE_AGENTS` pubkeys are needed.
 5. `LOAD_FULL` → `RUN_OPTIONAL_LOAD` → `CHECK_NEW` — continuous cycle: load nanopubs for trusted accounts, then optionally load for non-approved pubkeys (one per cycle), then check peers for new nanopubs and discover new pubkeys, then loop back to `LOAD_FULL`. Optional loading can be disabled with `REGISTRY_ENABLE_OPTIONAL_LOAD=false`
 6. `UPDATE` (10min after the previous recalculation finished) → `INIT_COLLECTIONS` — triggers a trust state recalculation (steps 2–4); the `LOAD_FULL` cycle (step 5) continues running during updates
+
+Some tasks run inside a MongoDB transaction, so that their writes commit atomically with their own removal from the queue; `Task.runAsTransaction()` says which, and defaults to true.
+A task opts out when it does network I/O or catalog operations (creating indexes, renaming or dropping collections), neither of which belongs in a transaction.
+Several pairs above exist for exactly that reason — `INIT_COLLECTIONS` prepares and fetches so that `SEED_TRUST_STATE` can write transactionally, and `RELEASE_DATA` renames so that `PUBLISH_TRUST_STATE` can.
+A task that stays non-transactional is re-executed after a crash and must be idempotent.
 
 See [Task.java](src/main/java/com/knowledgepixels/registry/Task.java).
 
@@ -272,7 +277,7 @@ Therefore, each account can only append its endorsements to the location in its 
 Downstream consumers (e.g. Nanopub Query) mirror the registry's trust state as immutable snapshots keyed by `trustStateHash`.
 To let them load a given trust state atomically and side-by-side with earlier states, the registry persists a structured snapshot each time the hash transitions.
 
-Snapshot writes happen inside `RELEASE_DATA` alongside the renames of the `_loading` collections.
+Snapshot writes happen inside `PUBLISH_TRUST_STATE`, which runs right after `RELEASE_DATA` has renamed the `_loading` collections into place.
 For each hash transition, a single document is upserted into the `trustStateSnapshots` collection:
 
     trustStateSnapshots:

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -131,6 +131,21 @@ public class RegistryDB {
     }
 
     /**
+     * Drops a collection, if it exists.
+     *
+     * <p>Like {@link #rename}, this is a catalog operation and therefore runs outside of any
+     * transaction, and it is idempotent: dropping a collection that is not there is a no-op.
+     *
+     * @param collectionName the name of the collection to drop
+     */
+    public static void drop(String collectionName) {
+        if (hasCollection(collectionName)) {
+            collection(collectionName).drop();
+            logger.debug("Dropped collection '{}'", collectionName);
+        }
+    }
+
+    /**
      * Checks if a collection with the given name exists in the database.
      *
      * @param collectionName the name of the collection to check

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -114,7 +114,7 @@ public enum Task implements Serializable {
             // potentially currently hardcoded in the nanopub lib
             setValue(s, Collection.SETTING.toString(), "bootstrap-services", bootstrapServices);
 
-            boolean performFullLoad = !"false".equals(System.getenv("REGISTRY_PERFORM_FULL_LOAD"));
+            boolean performFullLoad = !"false".equals(Utils.getEnv("REGISTRY_PERFORM_FULL_LOAD", null));
             if (performFullLoad) {
                 logger.debug("REGISTRY_PERFORM_FULL_LOAD not disabled; scheduling LOAD_FULL task");
                 schedule(s, LOAD_FULL);
@@ -947,6 +947,10 @@ public enum Task implements Serializable {
          * snapshot, the retention pruning and the server status transition. Transactional — every
          * write here is an ordinary document write on collections {@link #RELEASE_DATA} has
          * already renamed into place.
+         *
+         * <p>The very first state of a fresh registry is held back: nothing is recorded until a
+         * cycle finds the initial full load complete, so consumers never see the near-empty
+         * bootstrap state (see below).
          */
         public void run(ClientSession s, Document taskDoc) {
             ServerStatus status = getServerStatus(s);
@@ -954,8 +958,24 @@ public enum Task implements Serializable {
 
             String newTrustStateHash = taskDoc.get("newTrustStateHash").toString();
             String previousTrustStateHash = taskDoc.getString("previousTrustStateHash");  // may be null
+            String storedTrustStateHash = (String) getValue(s, Collection.SERVER_INFO.toString(), "trustStateHash");  // null until the first publication
 
-            if (previousTrustStateHash == null || !previousTrustStateHash.equals(newTrustStateHash)) {
+            if (storedTrustStateHash == null
+                    && !"false".equals(Utils.getEnv("REGISTRY_PERFORM_FULL_LOAD", null))
+                    && has(s, Collection.ACCOUNTS.toString(), new DbEntryWrapper(toLoad).getDocument())) {
+                // Bootstrap: nothing has ever been published and the just-released accounts are
+                // still waiting for their initial full load, so the computed state is the
+                // near-empty bootstrap one — every account still 'toLoad' is excluded from the
+                // hash and the snapshot (issue #119, calculateTrustStateHash). Publishing it would
+                // hand consumers a trust state containing essentially nobody, replaced as soon as
+                // loading finishes without any change in the network. Hold off instead until a
+                // cycle finds the initial load complete. Checked against the database rather than
+                // the server status because the initial load can span several update cycles, and
+                // because a re-run of the non-transactional RELEASE_DATA enqueues this task twice.
+                // Once something has been published, 'toLoad' accounts are normal between-cycles
+                // state (#119) and must not suppress publication.
+                logger.info("Initial full load not complete yet; not publishing bootstrap trust state {}", newTrustStateHash);
+            } else if (previousTrustStateHash == null || !previousTrustStateHash.equals(newTrustStateHash)) {
                 logger.info("Trust state changed ({} -> {}); recording new state and snapshot", previousTrustStateHash, newTrustStateHash);
                 // Bump the counter and record the hash only once per distinct trust state. This
                 // task is transactional, so it cannot half-apply — but RELEASE_DATA is not, and an
@@ -963,7 +983,6 @@ public enum Task implements Serializable {
                 // check has to be against the stored hash rather than against
                 // previousTrustStateHash from the task document, which still holds the value from
                 // before the first run and would let the counter drift on every duplicate.
-                String storedTrustStateHash = (String) getValue(s, Collection.SERVER_INFO.toString(), "trustStateHash");
                 if (newTrustStateHash.equals(storedTrustStateHash)) {
                     logger.info("Trust state {} was already recorded by an earlier run of this task; not bumping the counter again", newTrustStateHash);
                 } else {
@@ -1079,7 +1098,7 @@ public enum Task implements Serializable {
         public void run(ClientSession s, Document taskDoc) {
             logger.debug("LOAD_FULL invoked; taskDoc={}", taskDoc);
 
-            if ("false".equals(System.getenv("REGISTRY_PERFORM_FULL_LOAD"))) {
+            if ("false".equals(Utils.getEnv("REGISTRY_PERFORM_FULL_LOAD", null))) {
                 logger.info("REGISTRY_PERFORM_FULL_LOAD=false; skipping full load");
                 return;
             }

--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -130,10 +130,19 @@ public enum Task implements Serializable {
 
     INIT_COLLECTIONS {
 
-        // DB read from:
-        // DB write to:  trustPaths, endorsements, accounts
+        // DB read from: setting
+        // DB write to:  nanopubs
         // This state is periodically executed
 
+        /**
+         * Prepares the ground for a trust state cycle: resets the loading collections, creates
+         * their indexes, and fetches the agent intro collection into the local nanopub store.
+         *
+         * <p>Everything here is either a catalog operation or network I/O, so this task cannot be
+         * transactional. It deliberately holds no derived writes: those live in
+         * {@link #SEED_TRUST_STATE}, which runs afterwards and, because the intro collection is
+         * local by then, needs neither (issue #128).
+         */
         public void run(ClientSession s, Document taskDoc) throws Exception {
             logger.info("Running INIT_COLLECTIONS task");
             ServerStatus status = getServerStatus(s);
@@ -142,10 +151,67 @@ public enum Task implements Serializable {
                 throw new IllegalTaskStatusException("Illegal status for this task: " + status);
             }
 
+            // This task cannot run as a transaction (see runAsTransaction below), so it has to be
+            // idempotent instead: an interrupted run is re-executed from the same queue document.
+            // The _loading collections are scratch space that RELEASE_DATA renames away at the end
+            // of a cycle and that SEED_TRUST_STATE fills from scratch, so discarding whatever is
+            // there is always safe, and it is what keeps a retry from colliding with the fixed
+            // keys seeded by that task (issue #50).
+            for (String c : LOADING_COLLECTIONS) {
+                drop(c);
+            }
+
             IndexInitializer.initLoadingCollections(s);
 
-            if ("false".equals(System.getenv("REGISTRY_ENABLE_TRUST_CALCULATION"))) {
-                logger.info("Trust calculation disabled (REGISTRY_ENABLE_TRUST_CALCULATION=false); skipping to FINALIZE_TRUST_STATE");
+            // Read through Utils rather than System.getenv so tests can reach this branch; the two
+            // are equivalent in production, where the env reader delegates to System::getenv.
+            boolean trustCalculation = !"false".equals(Utils.getEnv("REGISTRY_ENABLE_TRUST_CALCULATION", null));
+            if (trustCalculation) {
+                // Pull the agent intro collection into the nanopub store now, so that the seeding
+                // below it resolves the index locally and stays off the network.
+                String agentIntroCollectionUri = Utils.getSetting().getAgentIntroCollection().stringValue();
+                logger.info("Retrieving base agent intro collection: {}", agentIntroCollectionUri);
+                loadNanopub(s, NanopubLoader.retrieveNanopub(s, agentIntroCollectionUri));
+                if (NanopubLoader.retrieveLocalNanopub(s, agentIntroCollectionUri) == null) {
+                    // retrieveNanopub returns the nanopub even when loadNanopub declined to store
+                    // it (size or triple count limits), which would send SEED_TRUST_STATE to the
+                    // network from inside its transaction. Fail here instead, where retrying is free.
+                    throw new RuntimeException("Agent intro collection could not be stored locally: " + agentIntroCollectionUri);
+                }
+            } else {
+                logger.info("Trust calculation disabled (REGISTRY_ENABLE_TRUST_CALCULATION=false); not retrieving the agent intro collection");
+            }
+
+            // Pass the decision on rather than re-reading the environment, so that both halves of
+            // the cycle are seeded from one observation of the flag.
+            schedule(s, SEED_TRUST_STATE.with("trustCalculation", trustCalculation));
+        }
+
+        @Override
+        public boolean runAsTransaction() {
+            // Drops and indexes the _loading collections, which is DDL, and fetches the agent
+            // intro collection over the network. Neither is permitted or bounded inside a
+            // transaction; the writes that follow from them are in SEED_TRUST_STATE. See #128.
+            return false;
+        }
+
+    },
+
+    SEED_TRUST_STATE {
+
+        // DB read from: nanopubs, setting
+        // DB write to:  trustPaths, endorsements, accounts
+
+        /**
+         * Seeds the loading collections for a fresh cycle, from data that
+         * {@link #INIT_COLLECTIONS} has already made local. Transactional: on a crash the whole
+         * seeding is rolled back and re-run, rather than half-applied (issue #128).
+         */
+        public void run(ClientSession s, Document taskDoc) throws Exception {
+            logger.info("Running SEED_TRUST_STATE task");
+
+            if (!taskDoc.getBoolean("trustCalculation", true)) {
+                logger.info("Trust calculation disabled; seeding explicit pubkeys and skipping to FINALIZE_TRUST_STATE");
                 for (Map.Entry<String, Integer> entry : AgentFilter.getExplicitPubkeys().entrySet()) {
                     String pubkeyHash = entry.getKey();
                     int quota = entry.getValue();
@@ -177,9 +243,14 @@ public enum Task implements Serializable {
             );
 
             String agentIntroCollectionUri = Utils.getSetting().getAgentIntroCollection().stringValue();
-            logger.info("Retrieving base agent intro collection: {}", agentIntroCollectionUri);
-            NanopubIndex agentIndex = IndexUtils.castToIndex(NanopubLoader.retrieveNanopub(s, agentIntroCollectionUri));
-            loadNanopub(s, agentIndex);
+            // Strictly local: INIT_COLLECTIONS has already stored this and verified it is here, so
+            // this must not fall back to the network the way retrieveNanopub would.
+            Nanopub agentIndexNp = NanopubLoader.retrieveLocalNanopub(s, agentIntroCollectionUri);
+            if (agentIndexNp == null) {
+                throw new RuntimeException("Agent intro collection is not available locally: " + agentIntroCollectionUri);
+            }
+            NanopubIndex agentIndex = IndexUtils.castToIndex(agentIndexNp);
+            String currentSetting = getValue(s, Collection.SETTING.toString(), "current").toString();
             for (IRI el : agentIndex.getElements()) {
                 String declarationAc = TrustyUriUtils.getArtifactCode(el.stringValue());
                 Validate.notNull(declarationAc);
@@ -188,7 +259,7 @@ public enum Task implements Serializable {
                         new Document("agent", "$")
                                 .append("pubkey", "$")
                                 .append("endorsedNanopub", declarationAc)
-                                .append("source", getValue(s, Collection.SETTING.toString(), "current").toString())
+                                .append("source", currentSetting)
                                 .append("status", toRetrieve.getValue())
 
                 );
@@ -337,6 +408,13 @@ public enum Task implements Serializable {
         // ------------------------------------------------------------
         // Only one trust edge per introduction is shown here, but
         // there can be several.
+
+        @Override
+        public boolean runAsTransaction() {
+            // Retrieves an agent intro over the network for every pending endorsement, each with
+            // up to ten retries, which would exceed MongoDB's transaction timeout. See #128.
+            return false;
+        }
 
     },
 
@@ -598,6 +676,13 @@ public enum Task implements Serializable {
         // Only one endorsement is shown here, but there are typically
         // several.
 
+        @Override
+        public boolean runAsTransaction() {
+            // Streams intros and endorsements from peers, and loads them through worker threads
+            // that each open their own session. Neither can join a transaction. See #128.
+            return false;
+        }
+
     },
 
     FINISH_ITERATION {
@@ -780,7 +865,7 @@ public enum Task implements Serializable {
             logger.info("Running DETERMINE_UPDATES task");
 
             // TODO Handle contested accounts properly:
-            for (Document d : collection("accounts_loading").find(
+            for (Document d : collection("accounts_loading").find(s,
                     new DbEntryWrapper(approved).getDocument())) {
                 // TODO Consider quota too:
                 Document accountId = new Document("agent", d.get("agent").toString()).append("pubkey", d.get("pubkey").toString());
@@ -815,11 +900,17 @@ public enum Task implements Serializable {
 
     RELEASE_DATA {
 
-        private static final int TRUST_STATE_SNAPSHOT_RETENTION = 100;
-
+        /**
+         * Publishes the cycle's results by renaming the loading collections over the live ones.
+         *
+         * <p>Renaming is a catalog operation and cannot run inside a transaction, which is the
+         * whole reason this task is separate: everything derived from the renamed collections —
+         * the counter, the snapshot, the status transition — is in {@link #PUBLISH_TRUST_STATE},
+         * which runs afterwards and so reads them through a snapshot that already includes them
+         * (issue #128).
+         */
         public void run(ClientSession s, Document taskDoc) {
-            ServerStatus status = getServerStatus(s);
-            logger.info("Running RELEASE_DATA task (current status: {})", status);
+            logger.info("Running RELEASE_DATA task (current status: {})", getServerStatus(s));
 
             String newTrustStateHash = taskDoc.get("newTrustStateHash").toString();
             String previousTrustStateHash = taskDoc.getString("previousTrustStateHash");  // may be null
@@ -831,16 +922,65 @@ public enum Task implements Serializable {
             rename("agents_loading", Collection.AGENTS.toString());
             rename("endorsements_loading", "endorsements");
 
+            schedule(s, PUBLISH_TRUST_STATE
+                    .with("newTrustStateHash", newTrustStateHash)
+                    .append("previousTrustStateHash", previousTrustStateHash));
+        }
+
+        @Override
+        public boolean runAsTransaction() {
+            // Renames the _loading collections into the live ones, which is DDL and cannot run
+            // inside a transaction. See #128. Both the renames and the rescheduling below them are
+            // idempotent, which is what PUBLISH_TRUST_STATE's own guard relies on: an interrupted
+            // run of this task is re-executed and enqueues that successor a second time.
+            return false;
+        }
+
+    },
+
+    PUBLISH_TRUST_STATE {
+
+        private static final int TRUST_STATE_SNAPSHOT_RETENTION = 100;
+
+        /**
+         * Records the newly released trust state: the counter, the debug row, the hash-keyed
+         * snapshot, the retention pruning and the server status transition. Transactional — every
+         * write here is an ordinary document write on collections {@link #RELEASE_DATA} has
+         * already renamed into place.
+         */
+        public void run(ClientSession s, Document taskDoc) {
+            ServerStatus status = getServerStatus(s);
+            logger.info("Running PUBLISH_TRUST_STATE task (current status: {})", status);
+
+            String newTrustStateHash = taskDoc.get("newTrustStateHash").toString();
+            String previousTrustStateHash = taskDoc.getString("previousTrustStateHash");  // may be null
+
             if (previousTrustStateHash == null || !previousTrustStateHash.equals(newTrustStateHash)) {
                 logger.info("Trust state changed ({} -> {}); recording new state and snapshot", previousTrustStateHash, newTrustStateHash);
-                increaseStateCounter(s);
-                setValue(s, Collection.SERVER_INFO.toString(), "trustStateHash", newTrustStateHash);
+                // Bump the counter and record the hash only once per distinct trust state. This
+                // task is transactional, so it cannot half-apply — but RELEASE_DATA is not, and an
+                // interrupted run of it enqueues this task a second time with the same hashes. The
+                // check has to be against the stored hash rather than against
+                // previousTrustStateHash from the task document, which still holds the value from
+                // before the first run and would let the counter drift on every duplicate.
+                String storedTrustStateHash = (String) getValue(s, Collection.SERVER_INFO.toString(), "trustStateHash");
+                if (newTrustStateHash.equals(storedTrustStateHash)) {
+                    logger.info("Trust state {} was already recorded by an earlier run of this task; not bumping the counter again", newTrustStateHash);
+                } else {
+                    increaseStateCounter(s);
+                    setValue(s, Collection.SERVER_INFO.toString(), "trustStateHash", newTrustStateHash);
+                }
                 Object trustStateCounter = getValue(s, Collection.SERVER_INFO.toString(), "trustStateCounter");
-                insert(s, "debug_trustPaths", new Document()
-                        .append("trustStateTxt", DebugPage.getTrustPathsTxt(s))
-                        .append("trustStateHash", newTrustStateHash)
-                        .append("trustStateCounter", trustStateCounter)
-                );
+                // Keyed on the counter, which is stable across retries thanks to the guard above,
+                // so a retry replaces this row instead of appending a duplicate. The
+                // trustStateCounter field is kept because DebugPage queries on it.
+                collection("debug_trustPaths").replaceOne(s,
+                        new Document("_id", trustStateCounter),
+                        new Document("_id", trustStateCounter)
+                                .append("trustStateTxt", DebugPage.getTrustPathsTxt(s))
+                                .append("trustStateHash", newTrustStateHash)
+                                .append("trustStateCounter", trustStateCounter),
+                        new ReplaceOptions().upsert(true));
 
                 // Structured hash-keyed snapshot for consumer mirroring (#107).
                 // Reads the accounts collection just renamed from accounts_loading above (:697).
@@ -913,7 +1053,7 @@ public enum Task implements Serializable {
 
             // Run update 10min after this cycle finishes (the delay is measured from the end of the
             // recompute, since this is the last task in the chain):
-            logger.debug("RELEASE_DATA complete; scheduling next UPDATE in 10min");
+            logger.debug("PUBLISH_TRUST_STATE complete; scheduling next UPDATE in 10min");
             schedule(s, UPDATE.withDelay(10 * 60 * 1000));
         }
 
@@ -1175,6 +1315,14 @@ public enum Task implements Serializable {
             }
         }
 
+        @Override
+        public boolean runAsTransaction() {
+            // Streams up to REGISTRY_OPTIONAL_LOAD_BATCH_SIZE nanopubs from peers and loads them
+            // through worker threads that each open their own session. Neither can join a
+            // transaction. See #128.
+            return false;
+        }
+
     },
 
     CHECK_NEW {
@@ -1294,6 +1442,14 @@ public enum Task implements Serializable {
     private static final int MAX_USER_QUOTA = Integer.parseInt(
             Utils.getEnv("REGISTRY_MAX_USER_QUOTA", "100000"));
 
+    /**
+     * The scratch collections a trust state cycle builds up, in the order in which
+     * {@link #RELEASE_DATA} renames them into their live counterparts. {@link #INIT_COLLECTIONS}
+     * resets them at the start of every cycle; nothing outside a cycle reads them.
+     */
+    private static final List<String> LOADING_COLLECTIONS = List.of(
+            "accounts_loading", "trustPaths_loading", "agents_loading", "endorsements_loading");
+
     private static MongoCollection<Document> tasksCollection = collection(Collection.TASKS.toString());
 
     private static volatile String currentTaskName;
@@ -1330,7 +1486,7 @@ public enum Task implements Serializable {
                         try {
                             s.startTransaction();
                             logger.debug("Transaction started for task {}", task.name());
-                            runTask(task, taskDoc);
+                            runTask(s, task, taskDoc);
                             s.commitTransaction();
                             logger.info("Transaction committed for task {}", task.name());
                         } catch (Exception ex) {
@@ -1343,7 +1499,7 @@ public enum Task implements Serializable {
                         }
                     } else {
                         try {
-                            runTask(task, taskDoc);
+                            runTask(s, task, taskDoc);
                         } catch (Exception ex) {
                             logger.warn("Non-transactional task {} failed: {}", task.name(), ex.getMessage(), ex);
                         }
@@ -1359,12 +1515,25 @@ public enum Task implements Serializable {
         }
     }
 
-    static void runTask(Task task, Document taskDoc) throws Exception {
+    /**
+     * Runs a single task on the given session.
+     *
+     * <p>The session belongs to the caller and carries the transaction, if any: for a task with
+     * {@link #runAsTransaction()}, {@link #runTasks} has already called
+     * {@code startTransaction()} on it, so the task's writes and the removal of the task from the
+     * queue below both join that transaction and commit together. Opening a session here instead
+     * would silently place both outside it (issue #128).
+     *
+     * @param s       the session to run on, with an active transaction for transactional tasks
+     * @param task    the task to run
+     * @param taskDoc the queue document describing this invocation
+     */
+    static void runTask(ClientSession s, Task task, Document taskDoc) throws Exception {
         currentTaskName = task.name();
         currentTaskStartTime = System.currentTimeMillis();
         logger.info("Starting task {} with request: {}", currentTaskName, taskDoc);
 
-        try (ClientSession s = RegistryDB.getClient().startSession()) {
+        try {
             task.run(s, taskDoc);
             long duration = System.currentTimeMillis() - currentTaskStartTime;
             tasksCollection.deleteOne(s, eq("_id", taskDoc.get("_id")));

--- a/src/main/java/com/knowledgepixels/registry/db/IndexInitializer.java
+++ b/src/main/java/com/knowledgepixels/registry/db/IndexInitializer.java
@@ -60,7 +60,7 @@ public final class IndexInitializer {
 
         collection(Collection.PEER_STATE.toString()).createIndex(mongoSession, ascending("setupId"));
 
-        // Supports pruning in RELEASE_DATA: sort by trustStateCounter desc, skip N, delete the tail.
+        // Supports pruning in PUBLISH_TRUST_STATE: sort by trustStateCounter desc, skip N, delete the tail.
         collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).createIndex(mongoSession, descending("trustStateCounter"));
     }
 

--- a/src/test/java/com/knowledgepixels/registry/TaskTest.java
+++ b/src/test/java/com/knowledgepixels/registry/TaskTest.java
@@ -218,6 +218,51 @@ class TaskTest {
         assertDoesNotThrow(() -> Task.runTask(mongoSession, Task.INIT_COLLECTIONS, Task.INIT_COLLECTIONS.asDocument()));
     }
 
+    /**
+     * A fresh registry's first computed trust state is the near-empty bootstrap one: every account
+     * is still 'toLoad' and therefore excluded from the hash and the snapshot (issue #119).
+     * PUBLISH_TRUST_STATE holds that state back — nothing is recorded until a cycle finds the
+     * initial full load complete — so consumers never see a trust state containing essentially
+     * nobody, replaced right afterwards without any change in the network.
+     */
+    @Test
+    void publishTrustStateHoldsBackBootstrapState() throws Exception {
+        ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.INIT_DB, Task.INIT_DB.asDocument());
+        Task.runTask(mongoSession, Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
+
+        TestUtils.copyResourceToDataDir("setting.trig");
+        fakeEnv.addVariable("REGISTRY_SETTING_FILE", TestUtils.getDataDir().resolve("setting.trig").toString()).build();
+        Task.runTask(mongoSession, Task.LOAD_SETTING, Task.LOAD_SETTING.asDocument());
+
+        long counterBefore = trustStateCounter(mongoSession);
+
+        // As after RELEASE_DATA on a fresh instance: the released accounts still await the full load
+        RegistryDB.insert(mongoSession, Collection.ACCOUNTS.toString(),
+                new Document("agent", "testAgent").append("pubkey", "testPubkey").append("status", EntryStatus.toLoad.getValue()));
+
+        Task.runTask(mongoSession, Task.PUBLISH_TRUST_STATE,
+                Task.PUBLISH_TRUST_STATE.asDocument().append("newTrustStateHash", "bootstrapHash"));
+
+        assertNull(getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateHash"), "the bootstrap state must not be recorded");
+        assertEquals(0, collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).countDocuments(mongoSession));
+        assertEquals(counterBefore, trustStateCounter(mongoSession), "the bootstrap state must not bump the trust state counter");
+        assertEquals(ServerStatus.coreReady.toString(), getValue(mongoSession, Collection.SERVER_INFO.toString(), "status"),
+                "holding back the state must not hold back the status transition");
+
+        // The initial full load completes, and the next cycle publishes its state as the first one
+        collection(Collection.ACCOUNTS.toString()).updateMany(mongoSession, new Document(),
+                new Document("$set", new Document("status", EntryStatus.loaded.getValue())));
+
+        Task.runTask(mongoSession, Task.PUBLISH_TRUST_STATE,
+                Task.PUBLISH_TRUST_STATE.asDocument().append("newTrustStateHash", "fullHash"));
+
+        assertEquals("fullHash", getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateHash"));
+        assertEquals(counterBefore + 1, trustStateCounter(mongoSession));
+        assertNotNull(collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).find(mongoSession, new Document("_id", "fullHash")).first(),
+                "the first published snapshot should be the post-load state");
+    }
+
     private static long trustStateCounter(ClientSession mongoSession) {
         return ((Number) getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateCounter")).longValue();
     }

--- a/src/test/java/com/knowledgepixels/registry/TaskTest.java
+++ b/src/test/java/com/knowledgepixels/registry/TaskTest.java
@@ -52,8 +52,8 @@ class TaskTest {
 
     @Test
     void initDB() throws Exception {
-        Task.runTask(Task.INIT_DB, Task.INIT_DB.asDocument());
         ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.INIT_DB, Task.INIT_DB.asDocument());
 
         assertEquals(ServerStatus.launching.toString(), getValue(mongoSession, Collection.SERVER_INFO.toString(), "status"));
         assertNotNull(RegistryDB.getValue(mongoSession, Collection.SERVER_INFO.toString(), "setupId"));
@@ -64,9 +64,9 @@ class TaskTest {
 
     @Test
     void loadConfig() throws Exception {
-        Task.runTask(Task.INIT_DB, Task.INIT_DB.asDocument());
-        Task.runTask(Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
         ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.INIT_DB, Task.INIT_DB.asDocument());
+        Task.runTask(mongoSession, Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
 
         assertNull(RegistryDB.getValue(mongoSession, Collection.SERVER_INFO.toString(), "coverageTypes"));
         assertNull(RegistryDB.getValue(mongoSession, Collection.SERVER_INFO.toString(), "coverageAgents"));
@@ -76,14 +76,14 @@ class TaskTest {
 
     @Test
     void loadSetting() throws Exception {
-        Task.runTask(Task.INIT_DB, Task.INIT_DB.asDocument());
-        Task.runTask(Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
+        ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.INIT_DB, Task.INIT_DB.asDocument());
+        Task.runTask(mongoSession, Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
 
         TestUtils.copyResourceToDataDir("setting.trig");
         fakeEnv.addVariable("REGISTRY_SETTING_FILE", TestUtils.getDataDir().resolve("setting.trig").toString()).build();
 
-        Task.runTask(Task.LOAD_SETTING, Task.LOAD_SETTING.asDocument());
-        ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.LOAD_SETTING, Task.LOAD_SETTING.asDocument());
 
         assertNotNull(RegistryDB.getValue(mongoSession, Collection.SETTING.toString(), "original"));
         assertNotNull(RegistryDB.getValue(mongoSession, Collection.SETTING.toString(), "current"));
@@ -104,15 +104,15 @@ class TaskTest {
 
     @Test
     void loadFull() throws Exception {
-        Task.runTask(Task.INIT_DB, Task.INIT_DB.asDocument());
-        Task.runTask(Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
+        ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.INIT_DB, Task.INIT_DB.asDocument());
+        Task.runTask(mongoSession, Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
 
         TestUtils.copyResourceToDataDir("setting.trig");
         fakeEnv.addVariable("REGISTRY_SETTING_FILE", TestUtils.getDataDir().resolve("setting.trig").toString()).build();
 
-        Task.runTask(Task.LOAD_SETTING, Task.LOAD_SETTING.asDocument());
-        Task.runTask(Task.LOAD_FULL, Task.LOAD_FULL.asDocument());
-        ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.LOAD_SETTING, Task.LOAD_SETTING.asDocument());
+        Task.runTask(mongoSession, Task.LOAD_FULL, Task.LOAD_FULL.asDocument());
 
         List<Document> retrievedTasks = RegistryDB.collection(Collection.TASKS.toString())
                 .find(mongoSession)
@@ -128,6 +128,98 @@ class TaskTest {
         assertTrue(actions.contains(Task.INIT_COLLECTIONS.name()));
         long loadFullCount = actions.stream().filter(a -> a.equals(Task.LOAD_FULL.name())).count();
         assertTrue(loadFullCount >= 2);
+    }
+
+    /**
+     * RELEASE_DATA renames collections, which is DDL, so it cannot be transactional and an
+     * interrupted run is re-executed from the same queue document on restart. That re-run enqueues
+     * PUBLISH_TRUST_STATE a second time with the same hashes, so the successor has to absorb the
+     * duplicate: no second counter bump, and no second debug row for the same state.
+     */
+    @Test
+    void publishTrustStateAbsorbsADuplicateFromReleaseData() throws Exception {
+        ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.INIT_DB, Task.INIT_DB.asDocument());
+        Task.runTask(mongoSession, Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
+
+        TestUtils.copyResourceToDataDir("setting.trig");
+        fakeEnv.addVariable("REGISTRY_SETTING_FILE", TestUtils.getDataDir().resolve("setting.trig").toString()).build();
+        Task.runTask(mongoSession, Task.LOAD_SETTING, Task.LOAD_SETTING.asDocument());
+
+        long counterBefore = trustStateCounter(mongoSession);
+
+        // previousTrustStateHash is absent, i.e. null, as on the first cycle of a fresh instance
+        Document releaseDoc = Task.RELEASE_DATA.asDocument().append("newTrustStateHash", "testTrustStateHash");
+        Task.runTask(mongoSession, Task.RELEASE_DATA, releaseDoc);
+        // ... interrupted before being dequeued, so the runner picks it up again
+        Task.runTask(mongoSession, Task.RELEASE_DATA, releaseDoc);
+
+        List<Document> queued = collection(Collection.TASKS.toString())
+                .find(mongoSession, new Document("action", Task.PUBLISH_TRUST_STATE.name()))
+                .into(new ArrayList<>());
+        assertEquals(2, queued.size(), "the interrupted re-run should have enqueued the successor twice");
+
+        Task.runTask(mongoSession, Task.PUBLISH_TRUST_STATE, queued.get(0));
+        long counterAfterFirst = trustStateCounter(mongoSession);
+        Task.runTask(mongoSession, Task.PUBLISH_TRUST_STATE, queued.get(1));
+        long counterAfterSecond = trustStateCounter(mongoSession);
+
+        assertEquals(counterBefore + 1, counterAfterFirst, "first run should record the new trust state");
+        assertEquals(counterAfterFirst, counterAfterSecond, "the duplicate must not bump the trust state counter again");
+        assertEquals("testTrustStateHash", getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateHash"));
+        assertEquals(1, collection("debug_trustPaths").countDocuments(mongoSession), "the duplicate must replace the debug row, not append one");
+        assertEquals(1, collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).countDocuments(mongoSession));
+    }
+
+    /**
+     * INIT_COLLECTIONS is not transactional (it drops and indexes collections and fetches the
+     * agent intro collection over the network), so an interrupted run leaves a partially prepared
+     * loading state behind and is re-executed from the same queue document on restart. The seeding
+     * that follows it used to fail on a duplicate key on every retry, forever (issue #50): both
+     * the root trust path and the base account are inserted under fixed keys. The task now resets
+     * the loading collections first, and the seeding itself moved to SEED_TRUST_STATE.
+     *
+     * <p>This exercises the reset with trust calculation disabled, which is the only branch that
+     * reaches no peers. The documents seeded below are the ones SEED_TRUST_STATE inserts under
+     * fixed keys, so their removal is what makes a retry collide-free; the enabled branch needs a
+     * peer stub to test and is not covered here.
+     */
+    @Test
+    void initCollectionsResetsLoadingCollections() throws Exception {
+        ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.INIT_DB, Task.INIT_DB.asDocument());
+        Task.runTask(mongoSession, Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
+
+        TestUtils.copyResourceToDataDir("setting.trig");
+        fakeEnv.addVariable("REGISTRY_SETTING_FILE", TestUtils.getDataDir().resolve("setting.trig").toString())
+                .addVariable("REGISTRY_ENABLE_TRUST_CALCULATION", "false")
+                .build();
+        Task.runTask(mongoSession, Task.LOAD_SETTING, Task.LOAD_SETTING.asDocument());
+
+        // Leftovers of a run interrupted partway through, under the keys it collides on
+        RegistryDB.insert(mongoSession, "trustPaths_loading", new Document("_id", "$").append("agent", "$").append("pubkey", "$"));
+        RegistryDB.insert(mongoSession, "accounts_loading", new Document("agent", "$").append("pubkey", "$"));
+        RegistryDB.insert(mongoSession, "endorsements_loading", new Document("agent", "$").append("pubkey", "$"));
+
+        Task.runTask(mongoSession, Task.INIT_COLLECTIONS, Task.INIT_COLLECTIONS.asDocument());
+
+        assertEquals(0, collection("trustPaths_loading").countDocuments(mongoSession), "stale trust paths must not survive the reset");
+        assertEquals(0, collection("endorsements_loading").countDocuments(mongoSession));
+        assertEquals(0, collection("accounts_loading").countDocuments(mongoSession, new Document("agent", "$")),
+                "the stale base account must be gone, so SEED_TRUST_STATE can re-insert it");
+
+        // The flag is observed once, here, and carried to the successor rather than re-read there
+        Document seedDoc = collection(Collection.TASKS.toString())
+                .find(mongoSession, new Document("action", Task.SEED_TRUST_STATE.name())).first();
+        assertNotNull(seedDoc, "INIT_COLLECTIONS should hand over to SEED_TRUST_STATE");
+        assertEquals(Boolean.FALSE, seedDoc.getBoolean("trustCalculation"));
+
+        // And the task itself is repeatable, which is the property the retry depends on
+        assertDoesNotThrow(() -> Task.runTask(mongoSession, Task.INIT_COLLECTIONS, Task.INIT_COLLECTIONS.asDocument()));
+    }
+
+    private static long trustStateCounter(ClientSession mongoSession) {
+        return ((Number) getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateCounter")).longValue();
     }
 
 }


### PR DESCRIPTION
Fixes #128. Fixes the root cause of #50.

## The bug

`runTasks()` started a transaction on the session it owned, then called `runTask()`, which opened a **fresh** session and passed that one to the task and to the queue deletion. MongoDB transactions are session-scoped, so nothing a task did ever joined the transaction — `commitTransaction`/`abortTransaction` operated on an empty one. Every task marked transactional in fact committed its writes piecemeal.

`runTask()` now takes the runner's session, so a transactional task's writes commit atomically with its own removal from the queue.

## Why that needed an audit first

`runAsTransaction()` defaults to `true` and only two tasks opted out, but seven cannot honour it. Simply threading the session through would have broken them. The [full audit is on the issue](https://github.com/knowledgepixels/nanopub-registry/issues/128#issuecomment-5251001973); the outcome:

| | |
|---|---|
| Now genuinely transactional | 13 of 20 tasks |
| Opted out, each commented with its blocker | `INIT_COLLECTIONS`, `LOAD_DECLARATIONS`, `LOAD_CORE`, `RELEASE_DATA`, `LOAD_FULL`, `RUN_OPTIONAL_LOAD`, `CHECK_NEW` |

`RUN_OPTIONAL_LOAD` was the trap: no override, so it inherited `true`, yet it does the most network work of any task.

## Two splits

Rather than leave the biggest tasks wholly non-transactional, each is split so the part that *can* be transactional is:

- **`RELEASE_DATA`** renames the `_loading` collections, which is DDL. Everything derived from them — counter, debug row, snapshot, pruning, status transition — moves to the new transactional **`PUBLISH_TRUST_STATE`**. This also removes the hazard recorded on `FINALIZE_TRUST_STATE`, where reads following the renames sat on a snapshot predating them.
- **`INIT_COLLECTIONS`** keeps the index creation and the agent intro collection fetch. The seeding writes move to the new transactional **`SEED_TRUST_STATE`**, which resolves the index strictly locally (`retrieveLocalNanopub`, not `retrieveNanopub`) so it can never reach a peer from inside its transaction.

## Idempotency for the tasks that stay out

Their `run()` and queue `deleteOne` remain non-atomic, so re-execution after a crash is part of their contract. Two did not meet it:

- **`INIT_COLLECTIONS`** seeded a root trust path (`_id: "$"`) and a base account (unique `(agent, pubkey)`) under fixed keys, so a retry died on a duplicate key on every attempt, forever — **the root cause of #50**, which #127 treats at the cycle level. It now resets the loading collections first, which makes the whole task repeatable rather than patching three inserts.
- **`PUBLISH_TRUST_STATE`** absorbs a duplicate enqueued by an interrupted `RELEASE_DATA`, keying its counter bump on the stored hash and its debug row on the counter instead of appending a fresh row.

`loadNanopub`'s write path was audited and needed no change — it is `has()`-guarded, duplicate-key tolerant, and runs its invalidation side effects only on first insert.

Also fixes a session-less `find` in `DETERMINE_UPDATES` that would have silently escaped the transaction.

## Tests

Three new tests in `TaskTest`, each verified to fail against the pre-fix code:

- `initCollectionsResetsLoadingCollections` — seeds the leftovers of an interrupted run under the colliding keys, asserts they are gone and the task is repeatable.
- `publishTrustStateAbsorbsADuplicateFromReleaseData` — runs `RELEASE_DATA` twice, asserts two successors queue, runs both, asserts one counter bump and one debug row.
- Existing tests updated for the new `runTask` signature.

Full suite green.

## Notes for review

- Both new tasks are additive enum constants, so a queue holding old `INIT_COLLECTIONS` or `RELEASE_DATA` documents across a deploy picks up the new behaviour and schedules the successor. No migration needed.
- One production read moved from `System.getenv` to `Utils.getEnv` (`REGISTRY_ENABLE_TRUST_CALCULATION`) so tests can reach that branch. Equivalent in production, where the env reader delegates to `System::getenv`.
- The four unbounded tasks (`EXPAND_TRUST_PATHS`, `CALCULATE_TRUST_SCORES`, `AGGREGATE_AGENTS`, `ASSIGN_PUBKEYS`) now hold real transactions across a whole-network sweep. They still terminate — MongoDB guarantees read-your-own-writes inside a transaction — but their duration is now bounded by the 60s transaction lifetime rather than by nothing. Comfortable at current scale; `LOAD_CORE`'s one-account-then-reschedule pattern is the fix if it ever bites.
- Deliberately **not** done: the same fetch-then-write split for `LOAD_DECLARATIONS`, `LOAD_CORE` and `RUN_OPTIONAL_LOAD`. They already guard every insert and advance status only per unit, so re-execution is safe; splitting them means threading fetched state through the queue for atomicity they do not need.

## What else is in this branch

The stack has collapsed — this PR is now the single one to review.

**#129 (merged into this branch, `38a5b95`)** — holds back the near-empty bootstrap trust state until the initial full load completes, so consumers never see a state containing essentially nobody. It also converts the two remaining `REGISTRY_PERFORM_FULL_LOAD` reads to `Utils.getEnv`, which is load-bearing rather than tidy-up: the hold-back's only exit is `LOAD_FULL` draining the `toLoad` accounts, so the two reads must agree or a registry could be held back forever.

**main merged in (`70d1412`)** — #127 landed while this was open and overlaps it, having independently fixed the same #50 duplicate-key failure. Resolved toward main's shape: its `RegistryDB` `LOADING_COLLECTIONS` map with `dropLoadingCollections()` / `promoteLoadingCollections()` replaces the equivalents added here, and the local `drop()` helper is gone as redundant.

One part of that needed extending rather than merging, and is the thing most worth a reviewer's eye:

`recoverInterruptedCycle()` enumerates the cycle's tasks, and this branch adds two it did not know about. `TRUST_CYCLE_TASKS` now includes `SEED_TRUST_STATE` and `PUBLISH_TRUST_STATE` — without that, a queued `SEED_TRUST_STATE` survives the restart and seeds into the collections the fresh cycle has just reset, colliding on the fixed keys it inserts under, which is the #50 failure the restart exists to prevent. The "cycle is complete, let it finish" exception is now keyed on the tail as a set (`TRUST_CYCLE_TAIL_TASKS`), since the tail is `RELEASE_DATA` followed by `PUBLISH_TRUST_STATE`; both are idempotent, so both are kept. Two tests cover this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
