### PR TITLE
Export endorsement edges in the trust state snapshot

### DIFF
--- a/src/main/java/com/knowledgepixels/registry/Task.java
+++ b/src/main/java/com/knowledgepixels/registry/Task.java
@@ -1023,17 +1023,66 @@ public enum Task implements Serializable {
                             .append("ratio", a.get("ratio"))
                             .append("quota", a.get("quota")));
                 }
+                // Agent-level endorsement edges between published accounts
+                // (nanopub-query#184). trustEdges is cumulative across cycles and
+                // never rebuilt, so membership in this state comes from filtering:
+                // only non-invalidated edges whose endpoints are both in the account
+                // set published above. The bootstrap seed rows (agent "$") fall out
+                // of the same filter, as "$" accounts are excluded from the snapshot.
+                // Additive envelope field, like 'name' (#113) and 'introNanopub'
+                // (#117/#118): older consumers ignore it.
+                Set<String> publishedAccountKeys = new HashSet<>();
+                for (Document a : snapshotAccounts) {
+                    publishedAccountKeys.add(a.getString("agent") + "|" + a.getString("pubkey"));
+                }
+                List<Document> publishedEdges = new ArrayList<>();
+                Set<String> edgeSourceAcs = new HashSet<>();
+                for (Document e : collection("trustEdges").find(s, new Document("invalidated", false))) {
+                    if (!publishedAccountKeys.contains(e.getString("fromAgent") + "|" + e.getString("fromPubkey"))
+                            || !publishedAccountKeys.contains(e.getString("toAgent") + "|" + e.getString("toPubkey"))) {
+                        continue;
+                    }
+                    publishedEdges.add(e);
+                    edgeSourceAcs.add(e.getString("source"));
+                }
+                // An edge's 'source' is the endorsement nanopub's artifact code; the
+                // envelope carries its full URI (matching the introNanopub field),
+                // resolved from the local nanopub store. An endorsement was by
+                // definition loaded, so the fallback for a missing local copy is a
+                // resolver-form URI rather than dropping the edge.
+                Map<String, String> sourceUriByAc = new HashMap<>();
+                if (!edgeSourceAcs.isEmpty()) {
+                    for (Document d : collection(Collection.NANOPUBS.toString())
+                            .find(s, new Document("_id", new Document("$in", new ArrayList<>(edgeSourceAcs))))
+                            .projection(new Document("fullId", 1))) {
+                        if (d.getString("fullId") != null) {
+                            sourceUriByAc.put(d.getString("_id"), d.getString("fullId"));
+                        }
+                    }
+                }
+                List<Document> snapshotEdges = new ArrayList<>(publishedEdges.size());
+                for (Document e : publishedEdges) {
+                    String sourceAc = e.getString("source");
+                    snapshotEdges.add(new Document()
+                            .append("fromAgent", e.getString("fromAgent"))
+                            .append("fromPubkey", e.getString("fromPubkey"))
+                            .append("toAgent", e.getString("toAgent"))
+                            .append("toPubkey", e.getString("toPubkey"))
+                            .append("viaNanopub", sourceUriByAc.getOrDefault(sourceAc, "https://w3id.org/np/" + sourceAc)));
+                }
+
                 Document snapshot = new Document()
                         .append("_id", newTrustStateHash)
                         .append("trustStateCounter", trustStateCounter)
                         .append("createdAt", ZonedDateTime.now().toString())
-                        .append("accounts", snapshotAccounts);
+                        .append("accounts", snapshotAccounts)
+                        .append("edges", snapshotEdges);
                 collection(Collection.TRUST_STATE_SNAPSHOTS.toString()).replaceOne(
                         s,
                         new Document("_id", newTrustStateHash),
                         snapshot,
                         new ReplaceOptions().upsert(true));
-                logger.debug("Saved trust state snapshot {} with {} account(s)", newTrustStateHash, snapshotAccounts.size());
+                logger.debug("Saved trust state snapshot {} with {} account(s) and {} edge(s)", newTrustStateHash, snapshotAccounts.size(), snapshotEdges.size());
 
                 // Prune beyond retention: collect _ids of snapshots past the Nth most recent, delete them.
                 // trustStateCounter is monotonically increasing (see increaseStateCounter above), so ordering is well-defined.

--- a/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
+++ b/src/main/java/com/knowledgepixels/registry/TrustStatePage.java
@@ -96,10 +96,10 @@ public class TrustStatePage extends Page {
     private void showList(String format) {
         int listed = 0;
         logger.debug("Querying trust-state snapshots collection (format={})", format);
-        // Metadata only — the accounts array is heavy and not needed in the index.
+        // Metadata only — the accounts and edges arrays are heavy and not needed in the index.
         try (MongoCursor<Document> it = collection(Collection.TRUST_STATE_SNAPSHOTS.toString())
                 .find(mongoSession)
-                .projection(exclude("accounts"))
+                .projection(exclude("accounts", "edges"))
                 .sort(descending("trustStateCounter"))
                 .cursor()) {
             if (TYPE_JSON.equals(format)) {
@@ -166,6 +166,12 @@ public class TrustStatePage extends Page {
                     .append("trustStateCounter", snapshot.get("trustStateCounter"))
                     .append("createdAt", snapshot.get("createdAt"))
                     .append("accounts", snapshot.get("accounts"));
+            // Additive field (nanopub-query#184): snapshots recorded before it exist
+            // without the array; keep the envelope free of an explicit null for those.
+            Object edges = snapshot.get("edges");
+            if (edges != null) {
+                output.append("edges", edges);
+            }
             print(output.toJson());
             return;
         }
@@ -191,6 +197,10 @@ public class TrustStatePage extends Page {
         Object accountsObj = snapshot.get("accounts");
         int accountCount = (accountsObj instanceof List) ? ((List<?>) accountsObj).size() : 0;
         println("<li><em>accountCount:</em> " + accountCount + "</li>");
+        Object edgesObj = snapshot.get("edges");
+        if (edgesObj instanceof List) {
+            println("<li><em>edgeCount:</em> " + ((List<?>) edgesObj).size() + "</li>");
+        }
         logger.debug("Snapshot {} has {} account entries (accountsObj type: {})", hash, accountCount, accountsObj == null ? "null" : accountsObj.getClass().getSimpleName());
         println("</ul>");
         println("<h3>Accounts</h3>");

--- a/src/test/java/com/knowledgepixels/registry/TaskTest.java
+++ b/src/test/java/com/knowledgepixels/registry/TaskTest.java
@@ -267,6 +267,71 @@ class TaskTest {
         return ((Number) getValue(mongoSession, Collection.SERVER_INFO.toString(), "trustStateCounter")).longValue();
     }
 
+    /**
+     * The snapshot carries the agent-level endorsement edges of the published state
+     * (nanopub-query#184). trustEdges is cumulative and never rebuilt, so the export must
+     * filter: invalidated edges, bootstrap seed edges (from the "$" account) and edges with
+     * an endpoint outside the published account set — such as an account that dropped out
+     * of the trust state in an earlier cycle — must all stay out. The 'source' artifact
+     * code is resolved to the endorsement nanopub's full URI via the local nanopub store,
+     * with the w3id.org resolver form as the fallback for a missing local copy.
+     */
+    @Test
+    void publishTrustStateExportsEndorsementEdges() throws Exception {
+        ClientSession mongoSession = RegistryDB.getClient().startSession();
+        Task.runTask(mongoSession, Task.INIT_DB, Task.INIT_DB.asDocument());
+        Task.runTask(mongoSession, Task.LOAD_CONFIG, Task.LOAD_CONFIG.asDocument());
+
+        TestUtils.copyResourceToDataDir("setting.trig");
+        fakeEnv.addVariable("REGISTRY_SETTING_FILE", TestUtils.getDataDir().resolve("setting.trig").toString()).build();
+        Task.runTask(mongoSession, Task.LOAD_SETTING, Task.LOAD_SETTING.asDocument());
+
+        // Published accounts: alice and bob; the "$" base account is excluded from the
+        // snapshot by the pubkey filter, and charlie left the trust state in an earlier
+        // cycle, so only his stale trustEdges rows remain.
+        RegistryDB.insert(mongoSession, Collection.ACCOUNTS.toString(),
+                new Document("agent", "$").append("pubkey", "$").append("status", EntryStatus.loaded.getValue()));
+        RegistryDB.insert(mongoSession, Collection.ACCOUNTS.toString(),
+                new Document("agent", "alice").append("pubkey", "pkA").append("status", EntryStatus.loaded.getValue()));
+        RegistryDB.insert(mongoSession, Collection.ACCOUNTS.toString(),
+                new Document("agent", "bob").append("pubkey", "pkB").append("status", EntryStatus.loaded.getValue()));
+
+        RegistryDB.insert(mongoSession, "trustEdges", new Document("fromAgent", "alice").append("fromPubkey", "pkA")
+                .append("toAgent", "bob").append("toPubkey", "pkB").append("source", "RAresolvable").append("invalidated", false));
+        RegistryDB.insert(mongoSession, "trustEdges", new Document("fromAgent", "bob").append("fromPubkey", "pkB")
+                .append("toAgent", "alice").append("toPubkey", "pkA").append("source", "RAunresolvable").append("invalidated", false));
+        RegistryDB.insert(mongoSession, "trustEdges", new Document("fromAgent", "alice").append("fromPubkey", "pkA")
+                .append("toAgent", "bob").append("toPubkey", "pkB").append("source", "RAretracted").append("invalidated", true));
+        RegistryDB.insert(mongoSession, "trustEdges", new Document("fromAgent", "alice").append("fromPubkey", "pkA")
+                .append("toAgent", "charlie").append("toPubkey", "pkC").append("source", "RAtostale").append("invalidated", false));
+        RegistryDB.insert(mongoSession, "trustEdges", new Document("fromAgent", "$").append("fromPubkey", "$")
+                .append("toAgent", "alice").append("toPubkey", "pkA").append("source", "RAseed").append("invalidated", false));
+
+        // Local copy of the resolvable endorsement nanopub, carrying its full URI.
+        RegistryDB.insert(mongoSession, Collection.NANOPUBS.toString(),
+                new Document("_id", "RAresolvable").append("fullId", "http://purl.org/np/RAresolvable"));
+
+        Task.runTask(mongoSession, Task.PUBLISH_TRUST_STATE,
+                Task.PUBLISH_TRUST_STATE.asDocument().append("newTrustStateHash", "edgeHash"));
+
+        Document snapshot = collection(Collection.TRUST_STATE_SNAPSHOTS.toString())
+                .find(mongoSession, new Document("_id", "edgeHash")).first();
+        assertNotNull(snapshot);
+        List<Document> edges = snapshot.getList("edges", Document.class);
+        assertEquals(2, edges.size(), "only non-invalidated edges between published accounts are exported");
+
+        Document aliceToBob = edges.stream().filter(e -> "alice".equals(e.getString("fromAgent"))).findFirst().orElseThrow();
+        assertEquals("bob", aliceToBob.getString("toAgent"));
+        assertEquals("pkA", aliceToBob.getString("fromPubkey"));
+        assertEquals("pkB", aliceToBob.getString("toPubkey"));
+        assertEquals("http://purl.org/np/RAresolvable", aliceToBob.getString("viaNanopub"),
+                "source artifact code is resolved to the locally stored full URI");
+
+        Document bobToAlice = edges.stream().filter(e -> "bob".equals(e.getString("fromAgent"))).findFirst().orElseThrow();
+        assertEquals("https://w3id.org/np/RAunresolvable", bobToAlice.getString("viaNanopub"),
+                "a source without a local copy falls back to the resolver-form URI");
+    }
+
     @Test
     void recoverInterruptedCycleRestartsTheCycle() throws Exception {
         ClientSession mongoSession = startCycleInterruptedAs(ServerStatus.updating);

--- a/src/test/java/com/knowledgepixels/registry/TrustStatePageTest.java
+++ b/src/test/java/com/knowledgepixels/registry/TrustStatePageTest.java
@@ -16,6 +16,7 @@ import org.mockito.MockedStatic;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -33,10 +34,16 @@ class TrustStatePageTest {
                         .append("status", "loaded").append("depth", 2).append("pathCount", 1)
                         .append("ratio", 0.25).append("quota", 500)
         );
+        List<Document> edges = List.of(
+                new Document("fromAgent", "https://orcid.org/0000-0000-0000-0001").append("fromPubkey", "pk1")
+                        .append("toAgent", "https://orcid.org/0000-0000-0000-0002").append("toPubkey", "pk2")
+                        .append("viaNanopub", "http://purl.org/np/RAendorsement1")
+        );
         return new Document("_id", HASH)
                 .append("trustStateCounter", 42L)
                 .append("createdAt", "2026-04-15T12:00:00Z")
-                .append("accounts", accounts);
+                .append("accounts", accounts)
+                .append("edges", edges);
     }
 
     @Test
@@ -55,6 +62,24 @@ class TrustStatePageTest {
             assertTrue(fullBody.contains("\"trustStateCounter\""), "envelope includes counter");
             assertTrue(fullBody.contains("\"accounts\""), "envelope includes accounts array");
             assertTrue(fullBody.contains("pk1") && fullBody.contains("pk2"), "accounts are serialized");
+            assertTrue(fullBody.contains("\"edges\""), "envelope includes edges array (nanopub-query#184)");
+            assertTrue(fullBody.contains("RAendorsement1"), "edges are serialized");
+        }
+    }
+
+    @Test
+    void omitsEdgesFieldForSnapshotsRecordedBeforeIt() {
+        // Snapshots stored before nanopub-query#184 have no edges array; the
+        // envelope must simply omit the field rather than emit an explicit null.
+        try (MockedStatic<RegistryDB> dbMock = mockStatic(RegistryDB.class)) {
+            Document legacy = makeSnapshot();
+            legacy.remove("edges");
+            HttpServerResponse response = setupMocks(dbMock, "/trust-state/" + HASH + ".json", legacy);
+
+            ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+            verify(response, atLeastOnce()).write(body.capture());
+            String fullBody = String.join("", body.getAllValues());
+            assertFalse(fullBody.contains("\"edges\""), "no edges key for a pre-#184 snapshot");
         }
     }
 


### PR DESCRIPTION
## Motivation

knowledgepixels/nanopub-query#184: the trust repo mirrors account states but not the endorsement edges between agents, so drawing the trust network requires reconstructing every edge from `npx:approvesOf` scans over the full repo — measured at 8–10 s against a 10 s gateway timeout for the global trust-network view.

The registry already maintains exactly the needed data in the `trustEdges` collection (with per-edge invalidation kept up to date on retraction); it just isn't exported. This PR adds it to the snapshot envelope so consumers can mirror the network directly.

## Changes

- **`Task.PUBLISH_TRUST_STATE`**: the hash-keyed snapshot gains an additive `edges` array — one row per non-invalidated `trustEdges` entry whose endpoints are both in the published account set, as `{fromAgent, fromPubkey, toAgent, toPubkey, viaNanopub}`. `trustEdges` is cumulative and never rebuilt, so this filter is what scopes the export to the current state; bootstrap seed edges (from the `"$"` account) and edges of accounts that dropped out in earlier cycles fall out of the same filter.
- **`viaNanopub`** carries the endorsement nanopub's full URI (matching the `introNanopub` field style), resolved from the local nanopub store's `fullId`; a source without a local copy falls back to the `https://w3id.org/np/<ac>` resolver form rather than dropping the edge.
- **`TrustStatePage`**: the JSON envelope passes `edges` through, omitting the key entirely for snapshots recorded before this change (no explicit `null`); the list endpoint excludes the array from its projection alongside `accounts`; the HTML detail view shows an `edgeCount` metadata line.

## Compatibility / deployment

- Additive envelope field, same pattern as `name` (#113) and `introNanopub` (#117/#118) — older consumers ignore it.
- `calculateTrustStateHash` is untouched: deploying this does not bump the trust state. The first edge-bearing snapshot appears with the next real trust-state change; retained pre-deploy snapshots keep serving unchanged.
- Per-cycle cost is one read-only pass over `trustEdges` plus one indexed `$in` lookup on `nanopubs`, inside the transaction `PUBLISH_TRUST_STATE` already runs.
- Known accepted caveat: a duplicate endorsement (same agent pair via a second nanopub) added or retracted without changing any trust path does not change the hash, so the edge list is eventually consistent until the next real state change.

## Tests

- `TaskTest.publishTrustStateExportsEndorsementEdges` covers the filter matrix (invalidated edge, seed edge, stale endpoint) plus URI resolution and the w3id fallback, against a real Mongo testcontainer.
- `TrustStatePageTest` covers envelope passthrough and the omitted-key behavior for pre-existing snapshots.

The consumer side (materializing `npa:EndorsementLink` nodes into the trust repo) is a separate nanopub-query PR; this one deploys first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)