### PR TITLE
feat: recognize npx:ProtectedNanopub type

### DIFF
--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -44,6 +44,8 @@ services:
 #     - REGISTRY_ENABLE_OPTIONAL_LOAD=false  # Disable loading nanopubs for non-approved pubkeys (discovered via peers)
 #     - REGISTRY_ENABLE_TRUST_CALCULATION=false  # Skip trust path calculation (use with explicit REGISTRY_COVERAGE_AGENTS)
 #     - REGISTRY_TEST_INSTANCE=true  # Set as test instance; only has an effect on DB initialization
+#     - REGISTRY_LOCAL_INSTANCE=true  # Local/private instance: accept nanopubs of type npx:ProtectedNanopub
+#                                     # (public instances reject them; do NOT enable on a public instance)
 #     - REGISTRY_SETTING_FILE=/data/registry.trig
 
       # ----------------------------------------------------------------------

--- a/src/main/java/com/knowledgepixels/registry/MainPage.java
+++ b/src/main/java/com/knowledgepixels/registry/MainPage.java
@@ -81,6 +81,7 @@ public class MainPage extends Page {
             println("<li><em>coverageAgents:</em> " + (serverInfo.get("coverageAgents") != null ? serverInfo.get("coverageAgents") : "viaSetting") + "</li>");
             println("<li><em>optionalLoadEnabled:</em> " + !"false".equals(System.getenv("REGISTRY_ENABLE_OPTIONAL_LOAD")) + "</li>");
             println("<li><em>trustCalculationEnabled:</em> " + !"false".equals(System.getenv("REGISTRY_ENABLE_TRUST_CALCULATION")) + "</li>");
+            println("<li><em>localInstance:</em> " + Utils.isLocalInstance() + "</li>");
             println("<li><em>status:</em> " + status + "</li>");
             println("<li><em>loadCounter:</em> " + getMaxValue(mongoSession, Collection.NANOPUBS.toString(), "counter") + "</li>");
             println("<li><em>nanopubCount:</em> " + collection(Collection.NANOPUBS.toString()).estimatedDocumentCount() + "</li>");

--- a/src/main/java/com/knowledgepixels/registry/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/registry/MainVerticle.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubImpl;
+import org.nanopub.extra.server.NanopubServerUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,6 +145,11 @@ public class MainVerticle extends AbstractVerticle {
                                 // Check if this nanopub's types are covered by this registry
                                 if (!CoverageFilter.isCovered(np)) {
                                     throw new RuntimeException("Nanopub types not covered by this registry: " + np.getUri());
+                                }
+
+                                // Protected nanopubs are only accepted on local/private instances:
+                                if (!Utils.isLocalInstance() && NanopubServerUtils.isProtectedNanopub(np)) {
+                                    throw new RuntimeException("Nanopub is protected and cannot be published to this registry: " + np.getUri());
                                 }
 
                                 // Verify signature once, pass through to avoid redundant verification:

--- a/src/main/java/com/knowledgepixels/registry/RegistryDB.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryDB.java
@@ -21,6 +21,7 @@ import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubUtils;
 import org.nanopub.extra.security.MalformedCryptoElementException;
+import org.nanopub.extra.server.NanopubServerUtils;
 import org.nanopub.extra.security.NanopubSignatureElement;
 import org.nanopub.extra.security.SignatureUtils;
 import org.nanopub.jelly.JellyUtils;
@@ -520,6 +521,10 @@ public class RegistryDB {
         }
         if (nanopub.getByteCount() > 1000000) {
             logger.error("Rejecting nanopub {}: size {} bytes exceeds limit of 1000000", nanopub.getUri(), nanopub.getByteCount());
+            return false;
+        }
+        if (!Utils.isLocalInstance() && NanopubServerUtils.isProtectedNanopub(nanopub)) {
+            logger.error("Rejecting nanopub {}: has type npx:ProtectedNanopub, which is only accepted on local/private instances", nanopub.getUri());
             return false;
         }
         Calendar creationTime;

--- a/src/main/java/com/knowledgepixels/registry/RegistryInfo.java
+++ b/src/main/java/com/knowledgepixels/registry/RegistryInfo.java
@@ -32,6 +32,7 @@ public class RegistryInfo implements Serializable {
     private Long nanopubCount;
     private Long loadCounter;
     private Boolean isTestInstance;
+    private Boolean isLocalInstance;
     private Boolean optionalLoadEnabled;
     private Boolean trustCalculationEnabled;
 
@@ -85,9 +86,10 @@ public class RegistryInfo implements Serializable {
         logger.debug("Counts: accountCount={}, nanopubCount={}", ri.accountCount, ri.nanopubCount);
 
         ri.isTestInstance = si.get("testInstance") != null && (Boolean) si.get("testInstance");
+        ri.isLocalInstance = Utils.isLocalInstance();
         ri.optionalLoadEnabled = !"false".equals(System.getenv("REGISTRY_ENABLE_OPTIONAL_LOAD"));
 
-        logger.info("RegistryInfo snapshot ready: version={}, status={}, setupId={}, isTestInstance={}, optionalLoadEnabled={}, trustCalculationEnabled={}", ri.registryVersion, ri.status, ri.setupId, ri.isTestInstance, ri.optionalLoadEnabled, ri.trustCalculationEnabled);
+        logger.info("RegistryInfo snapshot ready: version={}, status={}, setupId={}, isTestInstance={}, isLocalInstance={}, optionalLoadEnabled={}, trustCalculationEnabled={}", ri.registryVersion, ri.status, ri.setupId, ri.isTestInstance, ri.isLocalInstance, ri.optionalLoadEnabled, ri.trustCalculationEnabled);
 
         return ri;
     }

--- a/src/main/java/com/knowledgepixels/registry/Utils.java
+++ b/src/main/java/com/knowledgepixels/registry/Utils.java
@@ -158,6 +158,17 @@ public class Utils {
     }
 
     /**
+     * Checks whether this registry is configured as a local/private instance
+     * (environment variable REGISTRY_LOCAL_INSTANCE set to "true"). Local instances
+     * accept nanopubs of type npx:ProtectedNanopub, which are rejected otherwise.
+     *
+     * @return true if this registry is configured as a local/private instance
+     */
+    public static boolean isLocalInstance() {
+        return "true".equals(getEnv("REGISTRY_LOCAL_INSTANCE", "false"));
+    }
+
+    /**
      * Get the type hash for a given type, recording it in the database if necessary.
      *
      * @param mongoSession the MongoDB client session

--- a/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryDBTest.java
@@ -10,13 +10,16 @@ import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
 import org.nanopub.NanopubImpl;
 import org.nanopub.testsuite.NanopubTestSuite;
+import org.nanopub.vocabulary.NPX;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.mongodb.MongoDBContainer;
@@ -702,6 +705,64 @@ class RegistryDBTest {
         String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
         assertEquals(1, RegistryDB.collection(Collection.NANOPUBS.toString())
                 .countDocuments(session, new Document("_id", ac)));
+    }
+
+    /**
+     * Builds a minimal trusty nanopub, with the npx:ProtectedNanopub type either in the
+     * pubinfo graph (making it a protected nanopub) or in the assertion graph (where it
+     * has no such effect).
+     */
+    private Nanopub buildTestNanopub(boolean protectedTypeInPubinfo) throws Exception {
+        NanopubCreator creator = new NanopubCreator("http://example.org/protected-test-np/");
+        SimpleValueFactory vf = SimpleValueFactory.getInstance();
+        IRI thing = vf.createIRI("http://example.org/thing");
+        creator.addAssertionStatement(thing, vf.createIRI("http://www.w3.org/2000/01/rdf-schema#label"), vf.createLiteral("A thing"));
+        creator.addProvenanceStatement(vf.createIRI("http://www.w3.org/ns/prov#wasAttributedTo"), thing);
+        creator.addPubinfoStatement(vf.createIRI("http://purl.org/dc/terms/description"), vf.createLiteral("Test nanopub"));
+        if (protectedTypeInPubinfo) {
+            creator.addPubinfoStatement(RDF.TYPE, NPX.PROTECTED_NANOPUB);
+        } else {
+            creator.addAssertionStatement(thing, RDF.TYPE, NPX.PROTECTED_NANOPUB);
+        }
+        return creator.finalizeTrustyNanopub();
+    }
+
+    @Test
+    void loadNanopubVerifiedRejectsProtectedNanopub() throws Exception {
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        Nanopub nanopub = buildTestNanopub(true);
+        assertFalse(RegistryDB.loadNanopubVerified(session, nanopub, "test-pubkey", null));
+
+        String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
+        assertFalse(RegistryDB.has(session, Collection.NANOPUBS.toString(), ac));
+    }
+
+    @Test
+    void loadNanopubVerifiedAcceptsProtectedNanopubOnLocalInstance() throws Exception {
+        fakeEnv.addVariable("REGISTRY_LOCAL_INSTANCE", "true").build();
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        Nanopub nanopub = buildTestNanopub(true);
+        assertTrue(RegistryDB.loadNanopubVerified(session, nanopub, "test-pubkey", null));
+
+        String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
+        assertTrue(RegistryDB.has(session, Collection.NANOPUBS.toString(), ac));
+    }
+
+    @Test
+    void loadNanopubVerifiedAcceptsProtectedTypeOutsidePubinfo() throws Exception {
+        RegistryDB.init();
+        ClientSession session = RegistryDB.getClient().startSession();
+
+        // npx:ProtectedNanopub only takes effect as a pubinfo type of the nanopub itself
+        Nanopub nanopub = buildTestNanopub(false);
+        assertTrue(RegistryDB.loadNanopubVerified(session, nanopub, "test-pubkey", null));
+
+        String ac = TrustyUriUtils.getArtifactCode(nanopub.getUri().stringValue());
+        assertTrue(RegistryDB.has(session, Collection.NANOPUBS.toString(), ac));
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/registry/RegistryInfoTest.java
+++ b/src/test/java/com/knowledgepixels/registry/RegistryInfoTest.java
@@ -85,6 +85,7 @@ class RegistryInfoTest {
                                   + "\"nanopubCount\":" + NANOPUB_COUNT + ","
                                   + "\"loadCounter\":" + LOAD_COUNTER + ","
                                   + "\"isTestInstance\":" + IS_TEST_INSTANCE + ","
+                                  + "\"isLocalInstance\":false,"
                                   + "\"optionalLoadEnabled\":true,"
                                   + "\"trustCalculationEnabled\":true"
                                   + "}";
@@ -152,6 +153,7 @@ class RegistryInfoTest {
                                   + "\"nanopubCount\":" + NANOPUB_COUNT + ","
                                   + "\"loadCounter\":" + LOAD_COUNTER + ","
                                   + "\"isTestInstance\":" + IS_TEST_INSTANCE + ","
+                                  + "\"isLocalInstance\":false,"
                                   + "\"optionalLoadEnabled\":true,"
                                   + "\"trustCalculationEnabled\":true"
                                   + "}";

--- a/src/test/java/com/knowledgepixels/registry/UtilsTest.java
+++ b/src/test/java/com/knowledgepixels/registry/UtilsTest.java
@@ -68,6 +68,23 @@ class UtilsTest {
     }
 
     @Test
+    void isLocalInstanceDefaultsToFalse() {
+        assertFalse(Utils.isLocalInstance());
+    }
+
+    @Test
+    void isLocalInstanceWhenEnvVarSetToTrue() {
+        fakeEnv.addVariable("REGISTRY_LOCAL_INSTANCE", "true").build();
+        assertTrue(Utils.isLocalInstance());
+    }
+
+    @Test
+    void isLocalInstanceWhenEnvVarSetToOtherValue() {
+        fakeEnv.addVariable("REGISTRY_LOCAL_INSTANCE", "yes").build();
+        assertFalse(Utils.isLocalInstance());
+    }
+
+    @Test
     void getTypeWithInvalidExtension() {
         assertNull(Utils.getType("invalidExtension"));
     }


### PR DESCRIPTION
Closes #132

Rejects nanopubs typed as `npx:ProtectedNanopub` at load time, as the 1st-generation nanopub-server did, unless the instance is configured as local/private.

## Changes

- **`Utils.isLocalInstance()`**: reads the new `REGISTRY_LOCAL_INSTANCE` env var (default `false`), the registry's analogue of nanopub-server's `run.as.local.server` flag.
- **`RegistryDB.loadNanopubVerified()`**: rejects protected nanopubs (detected via `NanopubServerUtils.isProtectedNanopub()` from nanopub-java) on non-local instances, alongside the existing size/timestamp checks. All ingestion paths — POST, peer replication, on-demand fetches — funnel through this method, so one check covers them all; peer sync simply skips such nanopubs like other rejects.
- **`MainVerticle` POST handler**: explicit up-front check so publishers get a clear 400 ("Nanopub is protected...") instead of the generic failure message, matching nanopub-server's behavior.
- **`RegistryInfo` / `MainPage`**: the instance advertises `isLocalInstance` in its JSON info and HTML config listing, so peers and operators can see it is a private instance.
- **`docker-compose.override.yml.template`**: documents the new flag with a warning not to enable it on a public instance.

## Tests

- `RegistryDBTest`: protected nanopub rejected by default, accepted with `REGISTRY_LOCAL_INSTANCE=true`, and accepted when the `npx:ProtectedNanopub` IRI appears outside the pubinfo type position (only the pubinfo type triple on the nanopub itself triggers protection). Test nanopubs are built as real trusty nanopubs via `NanopubCreator.finalizeTrustyNanopub()`.
- `UtilsTest`: flag parsing, including that values other than exactly `"true"` stay false.
- `RegistryInfoTest`: expected JSON updated for the new field.

Full suite passes (206 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)